### PR TITLE
support a compatibility with interpolation format for rails and i18n-js

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -4,7 +4,7 @@
  *    https://github.com/Matt-Esch/string-template/index.js
  */
 
-const RE_NARGS = /\{([0-9a-zA-Z]+)\}/g
+const RE_NARGS = /(%|)\{([0-9a-zA-Z]+)\}/g
 
 
 /**
@@ -24,7 +24,7 @@ export default function (string, ...args) {
     args = {}
   }
 
-  return string.replace(RE_NARGS, (match, i, index) => {
+  return string.replace(RE_NARGS, (match, prefix, i, index) => {
     let result
 
     if (string[index - 1] === '{' &&

--- a/test/specs/format.js
+++ b/test/specs/format.js
@@ -11,6 +11,13 @@ describe('format', () => {
           name: 'kazupon', email: 'foo@domain.com'
         }), 'name: kazupon, email: foo@domain.com')
       })
+
+      it('should be replace with object value', () => {
+        let template = 'name: %{name}, email: %{email}'
+        assert(format(template, {
+          name: 'kazupon', email: 'foo@domain.com'
+        }), 'name: kazupon, email: foo@domain.com')
+      })
     })
 
     context('Array', () => {


### PR DESCRIPTION
Hi.
I using vuejs/vue-i18n with the rails in product.
also I would like to use the same string as the server side.
so, I made this pull request.

#### detail

- support a compatibility with interpolation format `%{}` for rails/i18n-js

###### rails
``` ruby
$ rails console
> I18n.t("hello %{text}", text: "world")
=> "hello world"
```

###### i18n-js gem
``` javascript
>> I18n.t("hello %{text}", { text: "world" })
"hello world"
```

###### vue-i18n (ver 2.4.0)
``` javascript
>> Vue.t("hello %{text}", { text: "world" })
"hello %world"
```

###### vue-i18n (this branch)
``` javascript
>> Vue.t("hello %{text}", { text: "world" })
"hello world"
```
