### PR TITLE
Adding linked translations

### DIFF
--- a/src/extend.js
+++ b/src/extend.js
@@ -40,8 +40,25 @@ export default function (Vue) {
   function interpolate (locale, key, args) {
     if (!locale) { return null }
 
-    const val = getValue(locale, key) || locale[key]
+    let val = getValue(locale, key) || locale[key]
     if (!val) { return null }
+
+    // Check for the existance of links within the translated string
+    if (val.indexOf('@:') >= 0) {
+      // Match all the links within the local
+      // We are going to replace each of
+      // them with its translation
+      const matches = val.match(/(@:[\w|\.]+)/g)
+      for (const idx in matches) {
+        const link = matches[idx]
+        // Remove the leading @:
+        const linkPlaceholder = link.substr(2)
+        // Translate the link
+        const translatedstring = interpolate(locale, linkPlaceholder, args)
+        // Replace the link with the translated string
+        val = val.replace(link, translatedstring)
+      }
+    }
 
     return args ? format(val, args) : val
   }

--- a/test/specs/fixture/locales.js
+++ b/test/specs/fixture/locales.js
@@ -7,7 +7,11 @@ export default {
         named: 'Hello {name}, how are you?',
         list: 'Hello {0}, how are you?'
       },
-      fallback: 'this is fallback'
+      fallback: 'this is fallback',
+      link: '@:message.hello',
+      link_end: 'This is a linked translation to @:message.hello',
+      link_within: 'Isn\'t @:message.hello we live in great?',
+      link_multiple: 'Hello @:message.hoge!, isn\'t @:message.hello great?'
     },
     'hello world': 'Hello World',
     'Hello {0}': 'Hello {0}',

--- a/test/specs/i18n.js
+++ b/test/specs/i18n.js
@@ -21,6 +21,30 @@ describe('i18n', () => {
       })
     })
 
+    describe('linked translation', () => {
+      it('should translate simple link', () => {
+        assert.equal(Vue.t('message.link'), locales.en.message.hello)
+      })
+    })
+
+    describe('linked translation', () => {
+      it('should translate link at the end of locale', () => {
+        assert.equal(Vue.t('message.link_end'), 'This is a linked translation to the world')
+      })
+    })
+
+    describe('linked translation', () => {
+      it('should translate link within a locale', () => {
+        assert.equal(Vue.t('message.link_within'), 'Isn\'t the world we live in great?')
+      })
+    })
+
+    describe('linked translation', () => {
+      it('should translate multiple links within a locale', () => {
+        assert.equal(Vue.t('message.link_multiple'), 'Hello hoge!, isn\'t the world great?')
+      })
+    })
+
     describe('ja language locale', () => {
       it('should translate a japanese', () => {
         assert.equal(Vue.t('message.hello', 'ja'), locales.ja.message.hello)


### PR DESCRIPTION
This adds the enhancement requested on issue #26.

The idea is the same as Angular translate.
After the string has been translated with the current mechanism, it will replace each occurrence of a link translation (linked translations are preceded by "@:") and replace them by the corresponding translation.

So if you have the following locales:
```
en: {
    message: {
      the_world: 'the world',
      hoge: 'hoge',
      linked: 'Hello @:message.hoge!, isn\'t @:message.the_world great?'
    }
}
```

The result of executing `$t('message.linked')` will be `Hello hoge!, isn't the world great?`