### PR TITLE
Zero choice

### DIFF
--- a/src/extend.js
+++ b/src/extend.js
@@ -5,7 +5,7 @@ import Path from './path'
 
 /**
  * extend
- * 
+ *
  * @param {Vue} Vue
  * @return {Vue}
  */
@@ -69,13 +69,13 @@ export default function (Vue) {
 
   function translate (getter, lang, fallback, key, params) {
     let res = null
-    res = interpolate(getter(lang), key, params) 
-    if (res) { return res } 
+    res = interpolate(getter(lang), key, params)
+    if (res) { return res }
 
-    res = interpolate(getter(fallback), key, params) 
+    res = interpolate(getter(fallback), key, params)
     if (res) {
       if (process.env.NODE_ENV !== 'production') {
-        warn('Fall back to translate the keypath "' + key + '" with "' 
+        warn('Fall back to translate the keypath "' + key + '" with "'
           + fallback + '" language.')
       }
       return res
@@ -102,10 +102,23 @@ export default function (Vue) {
     return this.$options.locales[lang]
   }
 
+  function getOldChoiceIndexFixed (choice) {
+    return choice ? choice > 1 ? 1 : 0 : 1
+  }
+
+  function getChoiceIndex (choice, choicesLength) {
+    choice = Math.abs(choice)
+
+    if (choicesLength === 2) return getOldChoiceIndexFixed(choice)
+
+    return choice ? Math.min(choice, 2) : 0
+  }
+
   function fetchChoice (locale, choice) {
     if (!locale && typeof locale !== 'string') { return null }
     const choices = locale.split('|')
-    choice = choice - 1
+
+    choice = getChoiceIndex(choice, choices.length)
     if (!choices[choice]) { return locale }
     return choices[choice].trim()
   }
@@ -135,7 +148,6 @@ export default function (Vue) {
    */
 
   Vue.tc = (key, choice, ...args) => {
-    if (!choice) { choice = 1 }
     return fetchChoice(Vue.t(key, ...args), choice)
   }
 
@@ -173,7 +185,6 @@ export default function (Vue) {
   Vue.prototype.$tc = function (key, choice, ...args) {
     if (typeof choice !== 'number'
       && typeof choice !== 'undefined') { return key }
-    if (!choice) { choice = 1 }
     return fetchChoice(this.$t(key, ...args), choice)
   }
 

--- a/test/specs/fixture/locales.js
+++ b/test/specs/fixture/locales.js
@@ -20,6 +20,7 @@ export default {
     underscore: '{hello_msg} world',
     plurals: {
       car: 'car | cars',
+      apple: 'no apples | one apple | {count} apples',
       format: {
         named: 'Hello {name}, how are you? | Hi {name}, you look fine',
         list: 'Hello {0}, how are you? | Hi {0}, you look fine'

--- a/test/specs/i18n.js
+++ b/test/specs/i18n.js
@@ -154,6 +154,16 @@ describe('i18n', () => {
   })
 
   describe('Vue.tc', () => {
+    describe('split plural with zero choice', () => {
+      it('should allow a zero choice, a one choice and a plural choice', () => {
+        const count = 10
+
+        assert.equal(Vue.tc('plurals.apple', 0), 'no apples')
+        assert.equal(Vue.tc('plurals.apple', 1), 'one apple')
+        assert.equal(Vue.tc('plurals.apple', count, { count }), '10 apples')
+      })
+    })
+
     describe('en language locale', () => {
       it('should translate an english', () => {
         assert.equal(Vue.tc('plurals.car', 1), 'car')


### PR DESCRIPTION
Added a possibility to specify a special text for an empty list for example. Also a fix was introduced for if a choice > 2 was used, as that would break the choices.

Now, if three options are specified, it will map the choice as follow:
```
choice => used index
--------------------
    0  => 0
    1  => 1
    2+ => 2
```

If only two options are specified, it will use indices:
```
choice => used index
--------------------
    0  => 1 // Following a '0 cars' thought: 0 cars, 1 car, 2+ cars
    1  => 0
    2+ => 1
```

I added a test to test for the above mentioned functionality and did not touch the remaining tests to ensure full backwards compatibility.