### PR TITLE
Named formatting: use name if value is missing

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -36,7 +36,7 @@ export default function (Vue) {
       } else {
         result = hasOwn(args, i) ? args[i] : null
         if (result === null || result === undefined) {
-          return ''
+          return match
         }
 
         return result


### PR DESCRIPTION
Consider the locales
```javascript
{
    foo: 'This {argument} is {missing}'
}
```
and use them as `$t('foo', {argument: 'test'})`.

Old behavior: `'This test is '`
New behavior: `'This test is {missing}'`