### PR TITLE
Server-side rendering fix

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,7 @@ export default function (Vue, langVM, lang) {
 
     return function computedGetter () {
       watcher.dirty && watcher.evaluate()
-      Dep.target && watcher.depend()
+      Dep && Dep.target && watcher.depend()
       return watcher.value
     }
   }

--- a/src/observer.js
+++ b/src/observer.js
@@ -28,7 +28,7 @@ let Dep
  */
 
 export function getDep (vm) {
-  if (!Dep) {
+  if (!Dep && vm && vm._data && vm._data.__ob__ && vm._data.__ob__.dep) {
     Dep = vm._data.__ob__.dep.constructor
   }
   return Dep


### PR DESCRIPTION
Hello,
I tried to fix problems with server-side rendering.

The problem is in `vm._data.__ob__`, which becomes undefined when SSR occurs. I have `{ langs: { en: { message: "translation"}}}` in `vm._data`, so this is fixed by [checking for `__ob__` existence](https://github.com/fandaa/vue-i18n/commit/9b894f4043eabd473266421b279704e30b102c50#diff-08f3e9ab539253c87ea111cc61c69e29R31).

Using of `Dep` is fixed by [this](https://github.com/fandaa/vue-i18n/commit/9b894f4043eabd473266421b279704e30b102c50#diff-9d9a6cd82f41984872a66a3ab0d440c4R19).

Didn't study the behavior of vue-i18n well, but it works (with vue-hackernews-2.0) and SSR.
