### PR TITLE
Add util functions that removed from Vue.util in Vue 2.2

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,11 @@
 import { getWatcher, getDep } from './observer'
+import { bind } from './util'
 
 let fallback // fallback lang
 let missingHandler = null // missing handler
 let i18nFormatter = null // custom formatter
 
 export default function (Vue, langVM, lang) {
-  const { bind } = Vue.util
   const Watcher = getWatcher(langVM)
   const Dep = getDep(langVM)
 

--- a/src/extend.js
+++ b/src/extend.js
@@ -1,7 +1,7 @@
 import warn from './warn'
 import Format from './format'
 import Path from './path'
-import { isNil } from './util'
+import { isNil, isObject, bind } from './util'
 
 /**
  * extend
@@ -11,7 +11,6 @@ import { isNil } from './util'
  */
 
 export default function (Vue) {
-  const { isObject, bind } = Vue.util
   const format = Format(Vue)
   const getValue = Path(Vue)
 

--- a/src/format.js
+++ b/src/format.js
@@ -1,4 +1,4 @@
-import { isNil } from './util'
+import { isNil, hasOwn } from './util'
 
 /**
  *  String format template
@@ -10,8 +10,6 @@ const RE_NARGS = /(%|)\{([0-9a-zA-Z_]+)\}/g
 
 
 export default function (Vue) {
-  const { hasOwn } = Vue.util
-
   /**
    * template
    *

--- a/src/path.js
+++ b/src/path.js
@@ -1,3 +1,5 @@
+import { isObject, isPlainObject, hasOwn } from './util'
+
 /**
  *  Path paerser
  *  - Inspired:
@@ -287,8 +289,6 @@ function parsePath (path) {
 }
 
 export default function (Vue) {
-  const { isObject, isPlainObject, hasOwn } = Vue.util
-
   function empty (target) {
     if (target === null || target === undefined) { return true }
 

--- a/src/util.js
+++ b/src/util.js
@@ -11,3 +11,62 @@
 export function isNil (val) {
   return val === null || val === undefined
 }
+
+/**
+ * bind
+ *
+ * @param {Function} fn
+ * @param {Object} ctx
+ * @return Function
+ */
+export function bind (fn, ctx) {
+  function boundFn (a) {
+    const l = arguments.length
+    return l
+      ? l > 1
+        ? fn.apply(ctx, arguments)
+        : fn.call(ctx, a)
+      : fn.call(ctx)
+  }
+  // record original fn length
+  boundFn._length = fn.length
+  return boundFn
+}
+
+/**
+ * isObject
+ *
+ * @param {*} obj
+ * @return Boolean
+ */
+export function isObject (obj) {
+  return obj !== null && typeof obj === 'object'
+}
+
+
+const toString = Object.prototype.toString
+const OBJECT_STRING = '[object Object]'
+
+/**
+ * isPlainObject
+ *
+ * @param {*} obj
+ * @return Boolean
+ */
+export function isPlainObject (obj) {
+  return toString.call(obj) === OBJECT_STRING
+}
+
+
+const hasOwnProperty = Object.prototype.hasOwnProperty
+
+/**
+ * hasOwn
+ *
+ * @param {*} obj
+ * @param {String} key
+ * @return Boolean
+ */
+export function hasOwn (obj, key) {
+  return hasOwnProperty.call(obj, key)
+}


### PR DESCRIPTION
4 util functions are removed, so I just make copies of them to util.js in this project.

* bind
* hasOwn
* isObject
* isPlainObject