### PR TITLE
Fix TypeError in mixin.js when using component with v-if

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -4,33 +4,39 @@ import VueI18n from './index'
 import { isPlainObject, warn } from './util'
 
 const $t = (vm: any): Function => {
-  // add dependency tracking !!
-  const locale: Locale = vm.$i18n.locale
-  /* eslint-disable no-unused-vars */
-  const fallback: Locale = vm.$i18n.fallbackLocal
-  /* eslint-enable no-unused-vars */
-  const messages: LocaleMessages = vm.$i18n.vm.messages
-  return (key: string, ...values: any): TranslateResult => {
-    return vm.$i18n._t(key, locale, messages, vm, ...values)
+  if (vm.$i18n) {
+    // add dependency tracking !!
+    const locale: Locale = vm.$i18n.locale
+    /* eslint-disable no-unused-vars */
+    const fallback: Locale = vm.$i18n.fallbackLocal
+    /* eslint-enable no-unused-vars */
+    const messages: LocaleMessages = vm.$i18n.vm.messages
+    return (key: string, ...values: any): TranslateResult => {
+      return vm.$i18n._t(key, locale, messages, vm, ...values)
+    }
   }
 }
 const $tc = (vm: any): Function => {
-  // add dependency tracking !!
-  const locale: Locale = vm.$i18n.locale
-  /* eslint-disable no-unused-vars */
-  const fallback: Locale = vm.$i18n.fallbackLocal
-  /* eslint-enable no-unused-vars */
-  const messages: LocaleMessages = vm.$i18n.vm.messages
-  return (key: string, choice?: number, ...values: any): TranslateResult => {
-    return vm.$i18n._tc(key, locale, messages, vm, choice, ...values)
+  if (vm.$i18n) {
+    // add dependency tracking !!
+    const locale: Locale = vm.$i18n.locale
+    /* eslint-disable no-unused-vars */
+    const fallback: Locale = vm.$i18n.fallbackLocal
+    /* eslint-enable no-unused-vars */
+    const messages: LocaleMessages = vm.$i18n.vm.messages
+    return (key: string, choice?: number, ...values: any): TranslateResult => {
+      return vm.$i18n._tc(key, locale, messages, vm, choice, ...values)
+    }
   }
 }
 const $te = (vm: any): Function => {
-  // add dependency tracking !!
-  const locale: Locale = vm.$i18n.locale
-  const messages: LocaleMessages = vm.$i18n.vm.messages
-  return (key: string, ...args: any): boolean => {
-    return vm.$i18n._te(key, locale, messages, ...args)
+  if (vm.$i18n) {
+    // add dependency tracking !!
+    const locale: Locale = vm.$i18n.locale
+    const messages: LocaleMessages = vm.$i18n.vm.messages
+    return (key: string, ...args: any): boolean => {
+      return vm.$i18n._te(key, locale, messages, ...args)
+    }
   }
 }
 


### PR DESCRIPTION
I got TypeErrors when disabling components using 'v-if'. In this scenario vm.$i18n is not set. See stacktrace below.
Checking vm.$i18n not to be null helps avoiding the error.

TypeError: Cannot read property 'locale' of null
    at $t (eval at <anonymous> (app.js:1717), <anonymous>:101:26)
    at VueComponent.options.computed.$t (eval at <anonymous> (app.js:1717), <anonymous>:148:46)
    at Watcher.get (eval at <anonymous> (app.js:798), <anonymous>:2461:25)
    at Watcher.evaluate (eval at <anonymous> (app.js:798), <anonymous>:2561:21)
    at Proxy.computedGetter (eval at <anonymous> (app.js:798), <anonymous>:2796:17)
    at n (backend.js:1)
    at n (backend.js:1)
    at n (backend.js:1)
    at n (backend.js:1)
    at n (backend.js:1)

