### PR TITLE
Fixed a typo in an example in gitbook

### DIFF
--- a/gitbook/en/started.md
+++ b/gitbook/en/started.md
@@ -20,7 +20,7 @@
 // If using a module system (e.g. via vue-cli), import Vue and VueI18n and then call Vue.use(VueI18n).
 // import Vue from 'vue'
 // import VueI18n from 'vue-i18n'
-// 
+//
 // Vue.use(VueI18n)
 
 // Ready translated locale messages
@@ -38,7 +38,7 @@ const messages = {
 }
 
 // Create VueI18n instance with options
-const i18n = new Vue18n({
+const i18n = new VueI18n({
   locale: 'ja', // set locale
   messages, // set locale messages
 })


### PR DESCRIPTION
@kazupon This typo is also present in the generated pages in `/docs/`, namely in `./docs/en/search_index.json`, `./docs/en/started.html`, `./docs/old/search_index.json`, `./docs/search_index.json`. I didn't touch them, however, since I though you'll auto-update them when building docs.

And you can also see the typo [here](http://kazupon.github.io/vue-i18n/en/started.html)