### PR TITLE
Fix `te()` that always uses `this.locale`, even when `locale` supplied

### DIFF
--- a/src/extend.js
+++ b/src/extend.js
@@ -13,6 +13,6 @@ export default function extend (Vue: any): void {
 
   Vue.prototype.$te = function (key: Path, locale?: Locale): boolean {
     const i18n = this.$i18n
-    return i18n._te(key, i18n.locale, i18n.messages, [locale])
+    return i18n._te(key, i18n.locale, i18n.messages, locale)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,7 @@ export default class VueI18n {
   }
 
   te (key: Path, locale?: Locale): boolean {
-    return this._te(key, this.locale, this.messages, [locale])
+    return this._te(key, this.locale, this.messages, locale)
   }
 
   getLocaleMessage (locale: Locale): LocaleMessage {

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -280,6 +280,10 @@ describe('basic', () => {
       it('should return false', () => {
         assert(i18n.te('message.hallo') === false)
       })
+
+      it('should return false with locale', () => {
+        assert(i18n.te('message.hello', 'xx') === false)
+      })
     })
   })
 
@@ -517,6 +521,11 @@ describe('basic', () => {
       it('should return false', () => {
         const vm = new Vue({ i18n })
         assert(vm.$te('message.hallo') === false)
+      })
+
+      it('should return false with locale', () => {
+        const vm = new Vue({ i18n })
+        assert(vm.$te('message.hello', 'xx') === false)
       })
     })
   })


### PR DESCRIPTION
@kazupon https://runkit.com/58f433eee5eaf000128e29fb/58f6482ef41b5b001249c3e7