### PR TITLE
bug(t): return `key` string when `PathValue` is an array, and ensure …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,6 @@ export default class VueI18n {
     if (!message) { return null }
 
     const pathRet: PathValue = getPathValue(message, key)
-    if (Array.isArray(pathRet)) { return pathRet }
 
     let ret: mixed
     if (isNull(pathRet)) {

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -92,6 +92,12 @@ describe('basic', () => {
       })
 
       describe('array keypath', () => {
+        describe('not specify index', () => {
+          it('should return key string', () => {
+            assert.equal(i18n.t('errors'), 'errors')
+          })
+        })
+
         describe('basic', () => {
           it('should be translated', () => {
             assert.equal(i18n.t('errors[0]'), messages.en.errors[0])


### PR DESCRIPTION
…that `t()` always return a string as described in API documentation

@kazupon https://runkit.com/58f433eee5eaf000128e29fb/59131731784810001209e5d8