### PR TITLE
Adding Discord channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://circleci.com/gh/kazupon/vue-i18n/tree/dev.svg?style=shield)](https://circleci.com/gh/kazupon/vue-i18n/tree/dev)
 [![Coverage Status](https://codecov.io/gh/kazupon/vue-i18n/branch/dev/graph/badge.svg)](https://codecov.io/gh/kazupon/vue-i18n)
 [![NPM version](https://badge.fury.io/js/vue-i18n.svg)](http://badge.fury.io/js/vue-i18n)
+[![vue-i18n channel on Discord](https://img.shields.io/badge/Discord-join%20chat-738bd7.svg)](https://discord.gg/4yCnk2m)
 
 Internationalization plugin for Vue.js
 


### PR DESCRIPTION
Hi @kazupon , as you might already know, [**Vue Land**](https://vue-land.surge.sh) is a Discord server for the whole Vue community, and we do have a channel for **vue-i18n**, would you mind adding a badge here?