### PR TITLE
IE11 Incompatible  'for...in' in VueI18n.prototype._link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -211,6 +211,11 @@ export default class VueI18n {
     // them with its translation
     const matches: any = ret.match(/(@:[\w\-_|.]+)/g)
     for (const idx in matches) {
+      // ie compatible: filter custom array
+      // prototype method
+      if (!matches.hasOwnProperty(idx)) {
+        continue
+      }
       const link: string = matches[idx]
       // Remove the leading @:
       const linkPlaceholder: string = link.substr(2)


### PR DESCRIPTION
<!-- BUG REPORT TEMPLATE -->
### vue-i18n version
7.0.3


add method to Array.prototype
VueI18n.prototype._link   throw error "substr is undefined " 
fix: use hasOwnProperty filter the pollyfill  array method
```javascript
  // Match all the links within the local
  // We are going to replace each of
  // them with its translation
  var matches = ret.match(/(@:[\w\-_|.]+)/g);
  for (var idx in matches) {
    if (matches.hasOwnProperty(idx)) {
      // logical code
    }
  }

