### PR TITLE
Update sfc.md

### DIFF
--- a/gitbook/en/sfc.md
+++ b/gitbook/en/sfc.md
@@ -132,7 +132,8 @@ mix.webpackConfig({
         ]
     },
     // ...
-});```
+});
+```
 
 ## YAML loading
 

--- a/gitbook/en/sfc.md
+++ b/gitbook/en/sfc.md
@@ -66,6 +66,74 @@ module.exports = {
 }
 ```
 
+## Laravel-Mix
+
+Laravel mix has its own rules for .vue files. To add the `vue-i18n-loader`, add the following to webpack.mix.js
+
+```js
+mix.webpackConfig({
+    // ...
+    module: {
+        rules: [
+            {
+                // Rules are copied from laravel-mix@1.5.1 /src/builder/webpack-rules.js and manually merged with the ia8n-loader. Make sure to update the rules to the latest found in webpack-rules.js
+                test: /\.vue$/,
+                loader: 'vue-loader',
+                exclude: /bower_components/,
+                options: {
+                    // extractCSS: Config.extractVueStyles,
+                    loaders: Config.extractVueStyles ? {
+                        js: {
+                            loader: 'babel-loader',
+                            options: Config.babel()
+                        },
+
+                        scss: vueExtractPlugin.extract({
+                            use: 'css-loader!sass-loader',
+                            fallback: 'vue-style-loader'
+                        }),
+
+                        sass: vueExtractPlugin.extract({
+                            use: 'css-loader!sass-loader?indentedSyntax',
+                            fallback: 'vue-style-loader'
+                        }),
+
+                        css: vueExtractPlugin.extract({
+                            use: 'css-loader',
+                            fallback: 'vue-style-loader'
+                        }),
+
+                        stylus: vueExtractPlugin.extract({
+                            use: 'css-loader!stylus-loader?paths[]=node_modules',
+                            fallback: 'vue-style-loader'
+                        }),
+
+                        less: vueExtractPlugin.extract({
+                            use: 'css-loader!less-loader',
+                            fallback: 'vue-style-loader'
+                        }),
+
+                        i18n: '@kazupon/vue-i18n-loader',
+                    } : {
+                        js: {
+                            loader: 'babel-loader',
+                            options: Config.babel()
+                        },
+
+                        i18n: '@kazupon/vue-i18n-loader',
+                    },
+                    postcss: Config.postCss,
+                    preLoaders: Config.vue.preLoaders,
+                    postLoaders: Config.vue.postLoaders,
+                    esModule: Config.vue.esModule
+                }
+            },
+            // ...
+        ]
+    },
+    // ...
+});```
+
 ## YAML loading
 
 `i18n` custom blocks need to specify `JSON` format, also you can use `YAML` format by using pre-loader feature of `vue-loader`.


### PR DESCRIPTION
Adding documentation to use vue-i18n-loader in Laravel using Laravel-mix. Code is based on laravel-mix 1.5.1, which is the current latest version and is by default shipped with Laravel 5.5

