### PR TITLE
fix import problem of vue2.5 because of the types update

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import * as Vue from 'vue';
+import Vue from 'vue';
 import { PluginFunction } from 'vue';
 
 declare namespace VueI18n {


### PR DESCRIPTION
vue2.5 now has an default export, so no need to import *.