### PR TITLE
Use new typescript syntax for exporting

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -129,4 +129,4 @@ declare module 'vue/types/options' {
   }
 }
 
-export = VueI18n;
+export default VueI18n;


### PR DESCRIPTION
Importing this module using the 
```typescript
import * as VueI18n from 'vue-i18n';
```
fails since it's not able to find the proper constructor when calling 
```typescript
new VueI18n({});
```

Now it can be imported like a normal ES2015 module using
```typescript
import VueI18n from 'vue-i18n';
```