### PR TITLE
Inherit formatter

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -34,6 +34,7 @@ export default {
         // component local i18n
         if (this.$root && this.$root.$i18n && this.$root.$i18n instanceof VueI18n) {
           options.i18n.root = this.$root.$i18n
+          options.i18n.formatter = this.$root.$i18n.formatter;
           options.i18n.fallbackLocale = this.$root.$i18n.fallbackLocale
           options.i18n.silentTranslationWarn = this.$root.$i18n.silentTranslationWarn
         }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -34,7 +34,7 @@ export default {
         // component local i18n
         if (this.$root && this.$root.$i18n && this.$root.$i18n instanceof VueI18n) {
           options.i18n.root = this.$root.$i18n
-          options.i18n.formatter = this.$root.$i18n.formatter;
+          options.i18n.formatter = this.$root.$i18n.formatter
           options.i18n.fallbackLocale = this.$root.$i18n.fallbackLocale
           options.i18n.silentTranslationWarn = this.$root.$i18n.silentTranslationWarn
         }

--- a/test/unit/format_custom.test.js
+++ b/test/unit/format_custom.test.js
@@ -38,6 +38,49 @@ describe('custom formatter', () => {
     })
   })
 
+  describe('via vue instance calling (mounted)', () => {
+    let el
+
+    beforeEach(done => {
+      el = document.createElement('div')
+      done()
+    })
+
+    it('should be inherited by components', done => {
+      new Vue({
+        i18n: new VueI18n({
+          locale: 'en',
+          formatter: {
+            interpolate: (message, values) => {
+              assert.deepEqual({ name: 'user' }, values)
+              done()
+              return ['pass']
+            }
+          }
+        }),
+        components: {
+          'child-1': {
+            render (h) {
+              return h('div', {}, [
+                h('p', {}, [this.$t('message', { name: 'user' })])
+              ])
+            },
+            i18n: {
+              messages: {
+                en: { message: 'hello {name}' }
+              }
+            }
+          }
+        },
+        render (h) {
+          return h('div', {}, [
+            h('child-1')
+          ])
+        }
+      }).$mount(el)
+    })
+  })
+
   describe('i18n format getter/settter', () => {
     it('should be worked', done => {
       const i18n = new VueI18n({


### PR DESCRIPTION
Hi. 

When using component based localization, you have to import custom formatter to all the components. This patch allows components to inherit root's formatter.

Live example: https://jsfiddle.net/xocaao6o/1/
Both lines should be 'custom formatted'

One test is failing in the branch on my local setup:
```
SUMMARY:
✔ 158 tests completed
✖ 1 test failed

FAILED TESTS:
  datetime format
    getDateTimeFormat / setDateTimeFormat
      ✖ should be worked
        HeadlessChrome 0.0.0 (Mac OS X 10.13.2)
      AssertionError:   # test/unit/datetime.test.js:50

        assert.equal(text.textContent, '2012/12/20 下午12:00')
                     |    |
                     |    "2012/12/20 上午7:00"
                     HTMLParagraphElement{__vue__:#Vue$3#}
```

but it looks not related to the diff.
  
  