### PR TITLE
There is no Array.prototype.contains

### DIFF
--- a/gitbook/en/lazy-loading.md
+++ b/gitbook/en/lazy-loading.md
@@ -45,7 +45,7 @@ function setI18nLanguage (lang) {
  
 export function loadLanguageAsync (lang) {
   if (i18n.locale !== lang) {
-    if (!loadedLanguages.contains(lang)) {
+    if (!loadedLanguages.includes(lang)) {
       return import(/* webpackChunkName: "lang-[request]" */ `@/lang/${lang}`).then(msgs => {
         i18n.setLocaleMessage(lang, msgs.default)
         loadedLanguages.push(lang)


### PR DESCRIPTION
`Array.prototype.contains` is not an ES standard. Use `Array.prototype.includes` instead: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes

