### PR TITLE
interpolate messages without values

### DIFF
--- a/decls/i18n.js
+++ b/decls/i18n.js
@@ -104,5 +104,5 @@ declare interface I18n {
 };
 
 declare interface Formatter {
-  interpolate (message: string, values: any): Array<any>
+  interpolate (message: string, values?: any): Array<any>
 };

--- a/src/format.js
+++ b/src/format.js
@@ -10,6 +10,9 @@ export default class BaseFormatter {
   }
 
   interpolate (message: string, values: any): Array<any> {
+    if (!values) {
+      return [message]
+    }
     let tokens: Array<Token> = this._caches[message]
     if (!tokens) {
       tokens = parse(message)

--- a/src/index.js
+++ b/src/index.js
@@ -210,7 +210,7 @@ export default class VueI18n {
       ret = this._link(locale, message, ret, host, interpolateMode, values)
     }
 
-    return !values ? ret : this._render(ret, interpolateMode, values)
+    return this._render(ret, interpolateMode, values)
   }
 
   _link (

--- a/test/unit/format_custom.test.js
+++ b/test/unit/format_custom.test.js
@@ -17,6 +17,22 @@ describe('custom formatter', () => {
       })
       i18n.t('message.hello', 'ja', { name: 'joe' })
     })
+
+    it('should interpolate messages without values', done => {
+      class CustomFormatter {
+        interpolate (message, values) {
+          assert(values === null)
+          done()
+        }
+      }
+      const formatter = new CustomFormatter()
+      const i18n = new VueI18n({
+        locale: 'en',
+        messages,
+        formatter
+      })
+      i18n.t('message.hello')
+    })
   })
 
   describe('via vue instance calling', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ declare namespace VueI18n {
   type NumberFormatResult = string;
 
   interface Formatter {
-    interpolate(message: string, values: Values): any[];
+    interpolate(message: string, values?: Values): any[];
   }
 
   type MissingHandler = (locale: Locale, key: Path, vm?: Vue) => void;


### PR DESCRIPTION
In some cases, a custom formatter might need to format a message despite no additional values. For example due to branding or personalization requirements. 