### PR TITLE
Add title to GitBook

### DIFF
--- a/gitbook/book.json
+++ b/gitbook/book.json
@@ -1,5 +1,6 @@
 {
   "gitbook": "3.x.x",
+  "title": "vue-i18n",
   "root": "./",
   "plugins": [
     "edit-link",
@@ -23,4 +24,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Add title to GitBook.
Because "GitBook" is used for page title when title is not specified.