### PR TITLE
Enable Setting Default Message instead of Code when Code not exists

### DIFF
--- a/decls/i18n.js
+++ b/decls/i18n.js
@@ -92,6 +92,7 @@ declare interface I18n {
   t (key: Path, ...values: any): TranslateResult,
   i (key: Path, locale: Locale, values: Object): TranslateResult,
   tc (key: Path, choice?: number, ...values: any): TranslateResult,
+  td (key: Path, defaultValue?: number, ...values: any): TranslateResult,
   te (key: Path, locale?: Locale): boolean,
   getDateTimeFormat (locale: Locale): DateTimeFormat,
   setDateTimeFormat (locale: Locale, format: DateTimeFormat): void,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ declare namespace VueI18n {
   type Locale = string;
   type Values = any[] | { [key: string]: any };
   type Choice = number;
+  type DefaultValue = string;
   type LocaleMessage = string | LocaleMessageObject | LocaleMessageArray;
   interface LocaleMessageObject { [key: string]: LocaleMessage; }
   interface LocaleMessageArray { [index: number]: LocaleMessage; }
@@ -100,6 +101,8 @@ declare class VueI18n {
   t(key: VueI18n.Path, locale: VueI18n.Locale, values?: VueI18n.Values): VueI18n.TranslateResult;
   tc(key: VueI18n.Path, choice?: VueI18n.Choice, values?: VueI18n.Values): string;
   tc(key: VueI18n.Path, choice: VueI18n.Choice, locale: VueI18n.Locale, values?: VueI18n.Values): string;
+  td(key: VueI18n.Path, defaultValue: VueI18n.defaultValue, values?: VueI18n.Values): string;
+  td(key: VueI18n.Path, defaultValue: VueI18n.defaultValue, locale: VueI18n.Locale, values?: VueI18n.Values): string;
   te(key: VueI18n.Path, locale?: VueI18n.Locale): boolean;
   d(value: number | Date, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;
@@ -128,6 +131,7 @@ declare module 'vue/types/vue' {
     readonly $i18n: VueI18n & IVueI18n;
     $t: typeof VueI18n.prototype.t;
     $tc: typeof VueI18n.prototype.tc;
+    $td: typeof VueI18n.prototype.td;
     $te: typeof VueI18n.prototype.te;
     $d: typeof VueI18n.prototype.d;
     $n: typeof VueI18n.prototype.n;


### PR DESCRIPTION
Currently there is no function for setting default message of code not exists.

if we put code not exists in message.json, the $t function returns initial code.
So what I added to code is below :

1. add function : td, checkDefault, _td, _checkDefault
2. enable setting default message when key code not exists.
 -> td(key, "default Message", paramArray)

e.g. this.$i18n.td("code.not-exists",  "default Message", ["param1","param2"])

message.json :
```
{
  "en" : {
    "code" : {
         "exists" : "Hello",
         "exists-2" : "Hi"
     }
  },
  "ko" : {
    "code" : {
         "exists" : "안녕하세요",
         "exists-2" : "하이"
     }
  }
}
```

Your Code  :
`this.$i18n.td("code.not-exists",  "Default Message", ["param1", "param2"])`

Result :
`Default Message`

There is no code of "code.not-exists" in message.json, the $td function returns "Default Message" as you set in your code.