### PR TITLE
Enable Setting Default Message instead of Code when Code not exists

### DIFF
--- a/decls/i18n.js
+++ b/decls/i18n.js
@@ -92,6 +92,7 @@ declare interface I18n {
   t (key: Path, ...values: any): TranslateResult,
   i (key: Path, locale: Locale, values: Object): TranslateResult,
   tc (key: Path, choice?: number, ...values: any): TranslateResult,
+  td (key: Path, defaultValue?: number, ...values: any): TranslateResult,
   te (key: Path, locale?: Locale): boolean,
   getDateTimeFormat (locale: Locale): DateTimeFormat,
   setDateTimeFormat (locale: Locale, format: DateTimeFormat): void,

--- a/dist/vue-i18n.esm.js
+++ b/dist/vue-i18n.esm.js
@@ -1116,24 +1116,6 @@ VueI18n.prototype._warnDefault = function _warnDefault (locale, key, result, vm,
   return key
 };
 
-VueI18n.prototype._checkDefault = function _checkDefault (locale, key, result, vm, values, defaultValue) {
-  if (!isNull(result)) { return result }
-  if (this._missing) {
-    var missingRet = this._missing.apply(null, [locale, key, vm, values]);
-    if (typeof missingRet === 'string') {
-      return missingRet
-    }
-  } else {
-    if (process.env.NODE_ENV !== 'production' && !this._silentTranslationWarn) {
-      warn(
-        "Cannot translate the value of keypath '" + key + "'. " +
-        'Use the default value.'
-      );
-    }
-  }
-  return defaultValue
-};
-
 VueI18n.prototype._isFallbackRoot = function _isFallbackRoot (val) {
   return !val && !isNull(this._root) && this._fallbackRoot
 };
@@ -1356,49 +1338,6 @@ VueI18n.prototype.tc = function tc (key, choice) {
   return (ref = this)._tc.apply(ref, [ key, this.locale, this._getMessages(), null, choice ].concat( values ))
     var ref;
 };
-
-
-VueI18n.prototype._td = function _td (
-  key,
-  _locale,
-  messages,
-  host,
-  defaultValue
-) {
-  var values = [], len = arguments.length - 5;
-  while ( len-- > 0 ) values[ len ] = arguments[ len + 5 ];
-
-  if (!key) { return '' }
-
-  var parsedArgs = parseArgs.apply(void 0, values);
-  var locale = parsedArgs.locale || _locale;
-
-  var ret = this._translate(
-    messages, locale, this.fallbackLocale, key,
-    host, 'string', parsedArgs.params
-  );
-  if (this._isFallbackRoot(ret)) {
-    if (process.env.NODE_ENV !== 'production' && !this._silentTranslationWarn) {
-      warn(("Fall back to translate the keypath '" + key + "' with root locale."));
-    }
-
-    if (!this._root) { throw Error('unexpected error') }
-    return (ref = this._root).t.apply(ref, [ key ].concat( values ))
-  } else {
-    return this._checkDefault(locale, key, ret, host, values, defaultValue)
-  }
-
-  var ref;
-};
-
-VueI18n.prototype.td = function td (key, defaultValue) {
-  var values = [], len = arguments.length - 2;
-  while ( len-- > 0 ) values[ len ] = arguments[ len + 2 ];
-
-  return (ref = this)._td.apply(ref, [ key, this.locale, this._getMessages(), null, defaultValue ].concat( values ))
-  var ref;
-};
-
 
 VueI18n.prototype._te = function _te (key, locale, messages) {
     var args = [], len = arguments.length - 3;

--- a/src/extend.js
+++ b/src/extend.js
@@ -20,6 +20,15 @@ export default function extend (Vue: any): void {
     }
   })
   // $FlowFixMe
+  Object.defineProperty(Vue.prototype, '$td', {
+    get () {
+      return (key: Path, defaultValue?: any, ...values: any): TranslateResult => {
+        const i18n = this.$i18n
+        return i18n._td(key, i18n.locale, i18n._getMessages(), this, defaultValue, ...values)
+      }
+    }
+  })
+  // $FlowFixMe
   Object.defineProperty(Vue.prototype, '$te', {
     get () {
       return (key: Path, locale?: Locale): boolean => {

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -307,6 +307,39 @@ describe('basic', () => {
     })
   })
 
+  
+  describe('i18n#td', () => {
+    describe('existing key', () => {
+      it('should return matched message with the key', () => {
+        assert.equal(i18n.td('message.hello', 'Default'), messages.en.message.hello)
+      })
+      
+      it('should return matched message with the key (named)', () => {
+        assert.equal(i18n.td('message.format.named', 'Default', {name : 'connie'}), 'Hello connie, how are you?')
+      })
+      
+      it('should return matched message with the key (list)', () => {
+        assert.equal(i18n.td('message.format.list', 'Default', ['connie']), 'Hello connie, how are you?')
+      })
+    })
+
+    describe('not existing key', () => {
+      it('should return User Default Message', () => {
+        assert.equal(i18n.td('message.helloNotExisting', 'Default'), 'Default')
+      })
+      
+      it('should return User Default Message', () => {
+        assert.equal(i18n.td('message.helloNotExisting', 'Named Default', {named : 'connie'}), 'Named Default')
+      })
+      
+      it('should return User Default Message', () => {
+        assert.equal(i18n.td('message.helloNotExisting', 'List Default', ['connie']), 'List Default')
+      })
+      
+    })
+  })
+  
+  
   describe('$t', () => {
     describe('en locale', () => {
       it('should translate an english', () => {
@@ -549,6 +582,43 @@ describe('basic', () => {
     })
   })
 
+  
+  describe('$td', () => {
+    describe('existing key', () => {
+      it('should return matched message with the key', () => {
+        const vm = new Vue({ i18n })
+        assert.equal(vm.$td('message.hello', 'Default'), messages.en.message.hello)
+      })
+
+      it('should return matched message with the key (named)', () => {
+        const vm = new Vue({ i18n })
+        assert.equal(vm.$td('message.format.named', 'Default', {name : 'connie'}), 'Hello connie, how are you?')
+      })
+      
+      it('should return matched message with the key (list)', () => {
+        const vm = new Vue({ i18n })
+        assert.equal(vm.$td('message.format.list', 'Default', ['connie']), 'Hello connie, how are you?')
+      })
+    })
+
+    describe('not existing key', () => {
+      it('should return User Default Message', () => {
+        const vm = new Vue({ i18n })
+        assert(vm.$td('message.helloNotExisting', 'Default'), 'Default')
+      })
+      
+      it('should return User Default Message', () => {
+        const vm = new Vue({ i18n })
+        assert(vm.$td('message.helloNotExisting', 'Named Default', {name : 'connie'}), 'Named Default')
+      })
+      
+      it('should return User Default Message', () => {
+        const vm = new Vue({ i18n })
+        assert(vm.$td('message.helloNotExisting', 'List Default', ['connie']), 'List Default')
+      })
+    })
+  })
+  
   describe('i18n#locale', () => {
     let el
     beforeEach(() => {

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -309,17 +309,21 @@ describe('basic', () => {
 
   
   describe('i18n#td', () => {
-    describe('existing key', () => {
-      it('should return matched message with the key', () => {
+    describe('existing key with default value', () => {
+      it('should return message matched with the key', () => {
         assert.equal(i18n.td('message.hello', 'Default'), messages.en.message.hello)
       })
-      
-      it('should return matched message with the key (named)', () => {
-        assert.equal(i18n.td('message.format.named', 'Default', {name : 'connie'}), 'Hello connie, how are you?')
+      it('should return matched message with the key in Japanese', () => {
+        assert.equal(i18n.td('message.hello', 'Default', 'ja'), messages.ja.message.hello)
       })
-      
-      it('should return matched message with the key (list)', () => {
-        assert.equal(i18n.td('message.format.list', 'Default', ['connie']), 'Hello connie, how are you?')
+      describe('existing key with default value and space to be replaced', () => {
+        it('should return replaced message (named)', () => {
+          assert.equal(i18n.td('message.format.named', 'Default', {name : 'connie'}), 'Hello connie, how are you?')
+        })
+        
+        it('should return replaced message (list)', () => {
+          assert.equal(i18n.td('message.format.list', 'Default', ['connie']), 'Hello connie, how are you?')
+        })
       })
     })
 
@@ -327,15 +331,18 @@ describe('basic', () => {
       it('should return User Default Message', () => {
         assert.equal(i18n.td('message.helloNotExisting', 'Default'), 'Default')
       })
-      
-      it('should return User Default Message', () => {
-        assert.equal(i18n.td('message.helloNotExisting', 'Named Default', {named : 'connie'}), 'Named Default')
+      it('should return User Default Message (include locale)', () => {
+        assert.equal(i18n.td('message.helloNotExisting', 'Default', 'ja'), 'Default')
       })
-      
-      it('should return User Default Message', () => {
-        assert.equal(i18n.td('message.helloNotExisting', 'List Default', ['connie']), 'List Default')
+      describe('should return User Default Message', () => {
+        it('should return User Default Message', () => {
+          assert.equal(i18n.td('message.helloNotExisting', 'Named Default', {named : 'connie'}), 'Named Default')
+        })
+        
+        it('should return User Default Message', () => {
+          assert.equal(i18n.td('message.helloNotExisting', 'List Default', ['connie']), 'List Default')
+        })
       })
-      
     })
   })
   
@@ -589,15 +596,30 @@ describe('basic', () => {
         const vm = new Vue({ i18n })
         assert.equal(vm.$td('message.hello', 'Default'), messages.en.message.hello)
       })
-
-      it('should return matched message with the key (named)', () => {
+      it('should return matched message with the key in Japanese', () => {
         const vm = new Vue({ i18n })
-        assert.equal(vm.$td('message.format.named', 'Default', {name : 'connie'}), 'Hello connie, how are you?')
+        assert.equal(vm.$td('message.hello', 'Default', 'ja'), messages.ja.message.hello)
       })
-      
-      it('should return matched message with the key (list)', () => {
-        const vm = new Vue({ i18n })
-        assert.equal(vm.$td('message.format.list', 'Default', ['connie']), 'Hello connie, how are you?')
+      describe('existing key with default value and space to be replaced', () => {
+        it('should return replaced message (named)', () => {
+          const vm = new Vue({ i18n })
+          assert.equal(vm.$td('message.format.named', 'Default', {name : 'connie'}), 'Hello connie, how are you?')
+        })
+        
+        it('should return replaced message in Japanese (named)', () => {
+          const vm = new Vue({ i18n })
+          assert.equal(vm.$td('message.format.named', 'Default', 'ja', {name : 'connie'}), 'こんにちは connie, ごきげんいかが？')
+        })
+        
+        it('should return replaced message (list)', () => {
+          const vm = new Vue({ i18n })
+          assert.equal(vm.$td('message.format.list', 'Default', ['connie']), 'Hello connie, how are you?')
+        })
+        
+        it('should return replaced message in Japanese (list)', () => {
+          const vm = new Vue({ i18n })
+          assert.equal(vm.$td('message.format.list', 'Default', 'ja', ['connie']), 'こんにちは connie, ごきげんいかが？')
+        })
       })
     })
 
@@ -606,15 +628,20 @@ describe('basic', () => {
         const vm = new Vue({ i18n })
         assert(vm.$td('message.helloNotExisting', 'Default'), 'Default')
       })
-      
-      it('should return User Default Message', () => {
+      it('should return matched message with the key in Japanese', () => {
         const vm = new Vue({ i18n })
-        assert(vm.$td('message.helloNotExisting', 'Named Default', {name : 'connie'}), 'Named Default')
+        assert.equal(vm.$td('message.helloNotExisting', 'Default', 'ja'), 'Default')
       })
-      
-      it('should return User Default Message', () => {
-        const vm = new Vue({ i18n })
-        assert(vm.$td('message.helloNotExisting', 'List Default', ['connie']), 'List Default')
+      describe('existing key with default value and space to be replaced', () => {
+        it('should return User Default Message', () => {
+          const vm = new Vue({ i18n })
+          assert(vm.$td('message.helloNotExisting', 'Named Default', {name : 'connie'}), 'Named Default')
+        })
+        
+        it('should return User Default Message', () => {
+          const vm = new Vue({ i18n })
+          assert(vm.$td('message.helloNotExisting', 'List Default', ['connie']), 'List Default')
+        })
       })
     })
   })

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -304,11 +304,13 @@ describe('issues', () => {
       const $t = vm.$t
       const $tc = vm.$t
       const $te = vm.$t
+      const $td = vm.$t
       const $d = vm.$t
       const $n = vm.$t
       assert.equal($t('hello'), 'hello #259')
       assert.equal($tc('hello'), 'hello #259')
       assert.equal($te('hello'), 'hello #259')
+      assert.equal($td('hello'), 'hello #259')
       assert.equal($d('hello'), 'hello #259')
       assert.equal($n('hello'), 'hello #259')
       done()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ declare namespace VueI18n {
   type Locale = string;
   type Values = any[] | { [key: string]: any };
   type Choice = number;
+  type DefaultValue = string;
   type LocaleMessage = string | LocaleMessageObject | LocaleMessageArray;
   interface LocaleMessageObject { [key: string]: LocaleMessage; }
   interface LocaleMessageArray { [index: number]: LocaleMessage; }
@@ -100,6 +101,8 @@ declare class VueI18n {
   t(key: VueI18n.Path, locale: VueI18n.Locale, values?: VueI18n.Values): VueI18n.TranslateResult;
   tc(key: VueI18n.Path, choice?: VueI18n.Choice, values?: VueI18n.Values): string;
   tc(key: VueI18n.Path, choice: VueI18n.Choice, locale: VueI18n.Locale, values?: VueI18n.Values): string;
+  td(key: VueI18n.Path, defaultValue: VueI18n.defaultValue, values?: VueI18n.Values): string;
+  td(key: VueI18n.Path, defaultValue: VueI18n.defaultValue, locale: VueI18n.Locale, values?: VueI18n.Values): string;
   te(key: VueI18n.Path, locale?: VueI18n.Locale): boolean;
   d(value: number | Date, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;
@@ -128,6 +131,7 @@ declare module 'vue/types/vue' {
     readonly $i18n: VueI18n & IVueI18n;
     $t: typeof VueI18n.prototype.t;
     $tc: typeof VueI18n.prototype.tc;
+    $td: typeof VueI18n.prototype.td;
     $te: typeof VueI18n.prototype.te;
     $d: typeof VueI18n.prototype.d;
     $n: typeof VueI18n.prototype.n;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -101,8 +101,8 @@ declare class VueI18n {
   t(key: VueI18n.Path, locale: VueI18n.Locale, values?: VueI18n.Values): VueI18n.TranslateResult;
   tc(key: VueI18n.Path, choice?: VueI18n.Choice, values?: VueI18n.Values): string;
   tc(key: VueI18n.Path, choice: VueI18n.Choice, locale: VueI18n.Locale, values?: VueI18n.Values): string;
-  td(key: VueI18n.Path, defaultValue: VueI18n.defaultValue, values?: VueI18n.Values): string;
-  td(key: VueI18n.Path, defaultValue: VueI18n.defaultValue, locale: VueI18n.Locale, values?: VueI18n.Values): string;
+  td(key: VueI18n.Path, defaultValue: VueI18n.DefaultValue, values?: VueI18n.Values): string;
+  td(key: VueI18n.Path, defaultValue: VueI18n.DefaultValue, locale: VueI18n.Locale, values?: VueI18n.Values): string;
   te(key: VueI18n.Path, locale?: VueI18n.Locale): boolean;
   d(value: number | Date, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -88,6 +88,8 @@ i18n.t;
 i18n.tc;
 // $ExpectType (key: string, locale?: string | undefined) => boolean
 i18n.te;
+// $ExpectType { (key: string, defaultValue?: string | undefined, values?: { [key: string]: any; } | undefined): string; (key: string, choice: number, locale: string, values?: { [key: string]: any; } | undefined): string; }
+i18n.td;
 // tslint:disable-next-line:max-line-length
 // $ExpectType { (value: number | Date, key?: string | undefined, locale?: string | undefined): string; (value: number | Date, args?: { [key: string]: string; } | undefined): string; }
 i18n.d;
@@ -117,6 +119,13 @@ vm.$tc(key, 1, locale, []);         // $ExpectType string
 vm.$tc(key, 1, locale, {});         // $ExpectType string
 vm.$te(key);                        // $ExpectType boolean
 vm.$te(key, locale);                // $ExpectType boolean
+vm.$td(key);                        // $ExpectType string
+vm.$td(key, 'x');                     // $ExpectType string
+vm.$td(key, 'x', []);                 // $ExpectType string
+vm.$td(key, 'x', {});                 // $ExpectType string
+vm.$td(key, 'x', locale);             // $ExpectType string
+vm.$td(key, 'x', locale, []);         // $ExpectType string
+vm.$td(key, 'x', locale, {});         // $ExpectType string
 vm.$d(1, key);                      // $ExpectType string
 vm.$d(1, key, locale);              // $ExpectType string
 vm.$d(new Date(), { key, locale }); // $ExpectType string
@@ -132,6 +141,7 @@ vm.$n(100, { key, locale });        // $ExpectType string
   let locale: VueI18n.Locale;
   let values: VueI18n.Values;
   let choice: VueI18n.Choice;
+  let defaultValue: VueI18n.DefaultValue;
   let localeMessage: VueI18n.LocaleMessage;
   let localeMessageObject: VueI18n.LocaleMessageObject;
   let localeMessageArray: VueI18n.LocaleMessageArray;


### PR DESCRIPTION
Currently there is no function for setting default message of code not exists.

if we put code not exists in message.json, the $t function returns initial code.
So what I added to code is below :

1. add function and prototype : td, checkDefault, _td, _checkDefault
2. enable setting default message when key code not exists.
 -> td(key, "default Message", locale, paramArray)

e.g. this.$i18n.td("code.not-exists",  "default Message", ["param1","param2"])

message.json :
```
{
  "en" : {
    "code" : {
         "exists" : "Hello {0} ",
         "exists-2" : "How are you?"
     }
  },
  "ja" : {
    "code" : {
         "exists" : "こんにちは {0}",
         "exists-2" : "ごきげんいかが？"
     }
  }
}
```

Your Code  :
`this.$i18n.td("code.not-exists",  "Default Message",  ["param1", "param2"])`
or for setting locale
`this.$i18n.td("code.not-exists",  "Default Message", "ja", ["param1", "param2"])`

Result :
`Default Message`

There is no code of "code.not-exists" in message.json, the $td function returns "Default Message" as you set in your code.

You can still set locale info like "ja", "en", etc... or set parameter for message to be replaced.