### PR TITLE
Fix description in Gitbook index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8">
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-        <title>Choose a language · vue-i18n</title>
+        <title>Choose a version · vue-i18n</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="description" content="">
         <meta name="generator" content="GitBook 3.2.3">
@@ -48,7 +48,7 @@
         
 <div class="book-langs-index" role="navigation">
     <div class="inner">
-        <h3>Choose a language</h3>
+        <h3>Choose a version</h3>
 
         <ul class="languages">
         


### PR DESCRIPTION
language -> version

In fact, we choose `version` instead of `language` in Gitbook's index.html of this project.