### PR TITLE
 docs: sfc: added webpack.config + vue-loader v15 examples 

### DIFF
--- a/gitbook/en/sfc.md
+++ b/gitbook/en/sfc.md
@@ -53,6 +53,28 @@ $ npm i --save-dev @kazupon/vue-i18n-loader
 
 For Webpack the configuration below is required:
 
+for vue-loader v15:
+```js
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+      },
+      {
+        resourceQuery: /blockType=i18n/,
+        loader: '@kazupon/vue-i18n-loader'
+      }
+      // ...
+    ]
+  },
+  // ...
+}
+```
+
+for vue-loader v14:
 ```js
 module.exports = {
   // ...
@@ -190,6 +212,31 @@ ja:
 
 Webpack conf the below:
 
+for vue-loader v15:
+```js
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+      },
+      {
+        resourceQuery: /blockType=i18n/,
+        use: [
+          {loader: '@kazupon/vue-i18n-loader'},
+          {loader: 'yaml-loader'}
+        ]
+      }
+      // ...
+    ]
+  },
+  // ...
+}
+```
+
+for vue-loader v14:
 ```js
 module.exports = {
   // ...


### PR DESCRIPTION
Hello!

I noticed that current documentation provides webpack.config examples using legacy version of vue-loader so I added examples for new one.

With vue-loader v15 we should use following rules:
```js
{ // vue
    test: /\.vue$/,
    loader: 'vue-loader',
},
{
    resourceQuery: /blockType=i18n/,
    use: [
        {loader: '@kazupon/vue-i18n-loader'},
        {loader: 'yaml-loader'}
    ]
}
```
instead of
```js
{
    test: /\.vue$/,
    loader: 'vue-loader',
    options: {
        preLoaders: {
            i18n: 'yaml-loader'
        },
        loaders: {
            i18n: '@kazupon/vue-i18n-loader'
        }
    }
}
```