### PR TITLE
Fix typings in components

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -136,7 +136,11 @@ declare module 'vue/types/vue' {
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
-    i18n?: VueI18n;
+    i18n?: {
+      messages?: VueI18n.LocaleMessages;
+      dateTimeFormats?: VueI18n.DateTimeFormats;
+      numberFormats?: VueI18n.NumberFormats;
+    };
   }
 }
 

--- a/types/test/component.ts
+++ b/types/test/component.ts
@@ -1,0 +1,43 @@
+import Vue, { ComponentOptions } from 'vue';
+import VueI18n from "../index";
+
+// setup locale info for root Vue instance
+const i18n = new VueI18n({
+  locale: 'ja',
+  messages: {
+    en: {
+      message: {
+        hello: 'hello world',
+        greeting: 'good morning'
+      }
+    },
+    ja: {
+      message: {
+        hello: 'こんにちは、世界',
+        greeting: 'おはようございます'
+      }
+    }
+  }
+})
+
+// Define component
+const Component1 = {
+  template: `
+    <div class="container">
+     <p>Component1 locale messages: {{ $t("message.hello") }}</p>
+     <p>Fallback global locale messages: {{ $t("message.greeting") }}</p>
+   </div>`,
+  i18n: { // `i18n` option
+    messages: {
+      en: { message: { hello: 'hello component1' } },
+      ja: { message: { hello: 'こんにちは、component1' } }
+    }
+  }
+}
+
+new Vue({
+  i18n,
+  components: {
+    Component1
+  }
+}).$mount('#app')


### PR DESCRIPTION
Typescript typings are incorrect for component options. Typescript expects entire VueI18n object and not just `messages`.
This does not allow to use "Component based localization" http://kazupon.github.io/vue-i18n/en/component.html

This fix allows to only set `messages`, `dateTimeFormats` and `numberFormats` as i18n options in vue component.
I added failing test case but I cannot find where typings are checked.