### PR TITLE
add supporting string keys with dots ($te returns always false )

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -298,6 +298,10 @@ export default class I18nPath {
   getPathValue (obj: mixed, path: Path): PathValue {
     if (!isObject(obj)) { return null }
 
+    if (obj[path] !== undefined) {
+      return (obj[path]: any)
+    }
+
     const paths: Array<string> = this.parsePath(path)
     if (empty(paths)) {
       return null

--- a/test/unit/path.test.js
+++ b/test/unit/path.test.js
@@ -9,6 +9,12 @@ describe('path', () => {
     })
   })
 
+  describe('string key with dots', () => {
+    it('should get path value', () => {
+      assert.equal(path.getPathValue({ 'a.b': 1 }, 'a.b'), 1)
+    })
+  })
+
   describe('object', () => {
     it('should get path value', () => {
       const val = path.getPathValue({ a: { b: 1 } }, 'a')


### PR DESCRIPTION
if we use keys with dots, like:
```json
{
   "ns.my-component.buttons.ok": "Ok",
   "ns.my-component.buttons.cancel": "Cancel",
}
```
$te returns  always false value
```vue
{{ $te('ns.my-component.buttons.ok') }} outs false
```
The path fixes that this
