### PR TITLE
Add chinese nested path support to fix #363

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { isObject } from './util'
+import { isObject, isChineseCharacter } from './util'
 
 /**
  *  Path paerser
@@ -136,6 +136,11 @@ function getPathCharType (ch: ?string): string {
 
   // a-z, A-Z
   if ((code >= 0x61 && code <= 0x7A) || (code >= 0x41 && code <= 0x5A)) {
+    return 'ident'
+  }
+
+  // chinese
+  if (isChineseCharacter(ch)) {
     return 'ident'
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -152,3 +152,7 @@ export const canUseDateTimeFormat: boolean =
 
 export const canUseNumberFormat: boolean =
   typeof Intl !== 'undefined' && typeof Intl.NumberFormat !== 'undefined'
+
+export function isChineseCharacter (character: string): boolean {
+  return /[\u4E00-\u9FA5]/g.test(character)
+}


### PR DESCRIPTION
To fix #363, Chinese characters are now treated as `indent` link `[a-zA-Z]` in function `getPathCharType ` at source file named `./src/path.js`