### PR TITLE
Add chinese nested path support to fix #363

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { isObject } from './util'
+import { isObject, isChineseCharacter } from './util'
 
 /**
  *  Path paerser
@@ -136,6 +136,11 @@ function getPathCharType (ch: ?string): string {
 
   // a-z, A-Z
   if ((code >= 0x61 && code <= 0x7A) || (code >= 0x41 && code <= 0x5A)) {
+    return 'ident'
+  }
+
+  // chinese
+  if (isChineseCharacter(ch)) {
     return 'ident'
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -152,3 +152,7 @@ export const canUseDateTimeFormat: boolean =
 
 export const canUseNumberFormat: boolean =
   typeof Intl !== 'undefined' && typeof Intl.NumberFormat !== 'undefined'
+
+export function isChineseCharacter (character: string): boolean {
+  return /[\u4E00-\u9FA5]/g.test(character)
+}

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -17,6 +17,10 @@ describe('basic', () => {
       it('should translate an english', () => {
         assert.equal(i18n.t('message.hello'), messages.en.message.hello)
       })
+
+      it('should support nested path contains chinese', () => {
+        assert.equal(i18n.t('嵌套.中文'), messages.en['嵌套']['中文'])
+      })
     })
 
     describe('empty string', () => {
@@ -52,6 +56,10 @@ describe('basic', () => {
     describe('ja locale', () => {
       it('should translate a japanese', () => {
         assert.equal(i18n.t('message.hello', 'ja'), messages.ja.message.hello)
+      })
+
+      it('should support nested path contains chinese', () => {
+        assert.equal(i18n.t('嵌套.中文'), messages.ja['嵌套']['中文'])
       })
     })
 

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -59,7 +59,7 @@ describe('basic', () => {
       })
 
       it('should support nested path contains chinese', () => {
-        assert.equal(i18n.t('嵌套.中文'), messages.ja['嵌套']['中文'])
+        assert.equal(i18n.t('嵌套.中文', 'ja'), messages.ja['嵌套']['中文'])
       })
     })
 

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -1,5 +1,8 @@
 export default {
   en: {
+    '嵌套': {
+      '中文': 'chinese'
+    },
     message: {
       hello: 'the world',
       hoge: 'hoge',
@@ -51,6 +54,9 @@ export default {
     }
   },
   ja: {
+    '嵌套': {
+      '中文': '中国語'
+    },
     message: {
       hello: 'ザ・ワールド',
       hoge: 'ほげ',


### PR DESCRIPTION
To fix #363, Chinese characters are now treated as indent link [a-zA-Z] in function getPathCharType at source file named ./src/path.js