### PR TITLE
add support for Vue.extend vue-i18n instance

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -28,7 +28,11 @@ export function install (_Vue) {
   Vue.directive('t', { bind, update, unbind })
   Vue.component(component.name, component)
 
-  // use object-based merge strategy
+  // use simple mergeStrategies to prevent i18n instance lose '__proto__'
   const strats = Vue.config.optionMergeStrategies
-  strats.i18n = strats.methods
+  strats.i18n = function (parentVal, childVal) {
+    return childVal === undefined
+      ? parentVal
+      : childVal
+  }
 }

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -595,6 +595,19 @@ describe('basic', () => {
     })
   })
 
+  describe('i18n#Vue.extend({ i18n })', () => {
+    it('should be translated', () => {
+      const el = document.createElement('div')
+      const Constructor = Vue.extend({ i18n })
+      const vm = new Constructor({
+        render (h) {
+          return h('p', { ref: 'text' }, [this.$t('message.hello')])
+        }
+      }).$mount(el)
+      assert.equal(vm.$refs.text.textContent, messages.en.message.hello)
+    })
+  })
+
   let desc = VueI18n.availabilities.dateTimeFormat ? describe : describe.skip
   desc('i18n#d', () => {
     let dt


### PR DESCRIPTION
To fix #200 , now we can use 
```
const i18n = new VueI18n({ ... })
const Constructor = Vue.extend({ i18n })
const vm = new Constructor({ ... }).$mount()
```