### PR TITLE
Should warn unknown if named format is not closed

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -45,14 +45,15 @@ export function parse (format: string): Array<Token> {
       text = ''
       let sub: string = ''
       char = format[position++]
-      while (char !== '}') {
+      while (char !== undefined && char !== '}') {
         sub += char
         char = format[position++]
       }
+      const isClosed = char === '}'
 
       const type = RE_TOKEN_LIST_VALUE.test(sub)
         ? 'list'
-        : RE_TOKEN_NAMED_VALUE.test(sub)
+        : isClosed && RE_TOKEN_NAMED_VALUE.test(sub)
           ? 'named'
           : 'unknown'
       tokens.push({ value: sub, type })

--- a/test/unit/format.test.js
+++ b/test/unit/format.test.js
@@ -85,6 +85,13 @@ describe('compile', () => {
       assert.equal(compiled[2], ', age: ')
       assert.equal(compiled[3], '0x20')
     })
+
+    it('should be compiled as unknown if not closed', () => {
+      const tokens = parse('name: {name')
+      const compiled = compile(tokens, { name: 'kazupon' })
+      assert(compiled.length === 1)
+      assert.equal(compiled[0], 'name: ')
+    })
   })
 
   describe('unknown token', () => {
@@ -102,6 +109,7 @@ describe('compile', () => {
       spy.restore()
     })
   })
+
 
   describe('values unknown mode', () => {
     it('should be compiled with empty', () => {


### PR DESCRIPTION
Closes #434 

I believe that: if `{named_format` is NOT closed (missing `}`) , the below `while` loops infintely and bloat the string variable `sub`, thus causes memory allocation error.
https://github.com/kazupon/vue-i18n/blob/94583e50391e78d5ca7afee3fde3195b9f6d3ff0/src/format.js#L48-L51

Personally, I prefer `error` to be thrown, so that one can notice the invalid named format while development.
But I follow the current design: logging `warn` rather than throwing `error`.
