### PR TITLE
Allow non-ascii key including numbers.

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -115,7 +115,6 @@ function getPathCharType (ch: ?string): string {
     case 0x2E: // .
     case 0x22: // "
     case 0x27: // '
-    case 0x30: // 0
       return ch
 
     case 0x5F: // _
@@ -134,15 +133,7 @@ function getPathCharType (ch: ?string): string {
       return 'ws'
   }
 
-  // a-z, A-Z
-  if ((code >= 0x61 && code <= 0x7A) || (code >= 0x41 && code <= 0x5A)) {
-    return 'ident'
-  }
-
-  // 1-9
-  if (code >= 0x31 && code <= 0x39) { return 'number' }
-
-  return 'else'
+  return 'ident'
 }
 
 /**

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -18,8 +18,12 @@ export default {
       linkList: '@:message.hello: {0} {1}',
       'hyphen-locale': 'hello hyphen',
       '1234': 'Number-based keys are found',
-      '1mixedKey': 'Mixed keys are not found.'
+      '1mixedKey': 'Mixed keys are not found.',
+      'sálvame': 'save me'
     },
+    '0123a': 'Starts with number and contains non-number',
+    '01234': 'Numeric only',
+    '日本語': 'Japanese',
     'hello world': 'Hello World',
     'Hello {0}': 'Hello {0}',
     'continue-with-new-account': 'continue with new account',
@@ -62,8 +66,12 @@ export default {
       fallback1: 'これはフォールバック',
       'hyphen-locale': 'こんにちは、ハイフン',
       '1234': '数字ベースのキーは見つかりませんでした。',
-      '1mixedKey': 'ミックスされたキーは見つかりませんでした。'
+      '1mixedKey': 'ミックスされたキーは見つかりませんでした。',
+      'sálvame': '私を助けて'
     },
+    '01234': '数字のみ',
+    '12345a': '数字で始まり、数字以外を含む',
+    '日本語': '日本語',
     plurals: {
       car: 'ザ・ワールド | これはフォールバック',
       format: {

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -343,4 +343,25 @@ describe('issues', () => {
       })
     })
   })
+
+  describe('#398', () => {
+    it('should return true', () => {
+      assert.strictEqual(vm.$te('0123a'), true)
+      assert.strictEqual(vm.$te('01234'), true)
+      assert.strictEqual(vm.$te('message.1234'), true)
+    })
+  })
+
+  describe('#430', () => {
+    it('should be translated', () => {
+      assert.strictEqual(
+        vm.$t('日本語'),
+        messages[vm.$i18n.locale]['日本語']
+      )
+      assert.strictEqual(
+        vm.$t('message.sálvame'),
+        messages[vm.$i18n.locale]['message']['sálvame']
+      )
+    })
+  })
 })


### PR DESCRIPTION
Closes #398 and #430 

I am a little suprised that the change in `getPathCharType` does not break the existing tests.
I hope mainaters to review PR very carefully and give me a guidance.