### PR TITLE
Add warning for circular reference in linked message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,6 +294,8 @@ export default class VueI18n {
         Array.isArray(values) ? values : [values]
       )
 
+      visitedLinks.delete(linkPlaceholder)
+
       // Replace the link with the translated
       ret = !translated ? ret : ret.replace(link, translated)
     }

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -16,9 +16,10 @@ export default {
       linkHyphen: '@:hyphen-hello',
       linkUnderscore: '@:underscore_hello',
       linkList: '@:message.hello: {0} {1}',
-      circular1: 'Welcome @:message.circular2',
-      circular2: 'Elon @:message.circular3',
-      circular3: '@:message.circular1 foo',
+      circular1: 'Foo @:message.circular2',
+      circular2: 'Bar @:message.circular3',
+      circular3: 'Buz @:message.circular1',
+      linkTwice: '@:message.hello: @:message.hello',
       'hyphen-locale': 'hello hyphen',
       '1234': 'Number-based keys are found',
       '1mixedKey': 'Mixed keys are not found.'

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -16,6 +16,9 @@ export default {
       linkHyphen: '@:hyphen-hello',
       linkUnderscore: '@:underscore_hello',
       linkList: '@:message.hello: {0} {1}',
+      circular1: 'Welcome @:message.circular2',
+      circular2: 'Elon @:message.circular3',
+      circular3: '@:message.circular1 foo',
       'hyphen-locale': 'hello hyphen',
       '1234': 'Number-based keys are found',
       '1mixedKey': 'Mixed keys are not found.'

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -300,6 +300,16 @@ describe('issues', () => {
     })
   })
 
+  describe('#247', () => {
+    it('should warn if circular reference in linked locale message', () => {
+      const spy = sinon.spy(console, 'warn')
+      vm.$i18n.t('message.circular1')
+      assert(spy.notCalled === false)
+      assert(spy.callCount === 1)
+      spy.restore()
+    })
+  })
+
   describe('#377', () => {
     it('should be destroyed', done => {
       const el = document.createElement('div')

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -303,7 +303,7 @@ describe('issues', () => {
   describe('#247', () => {
     it('should be warned if circular reference in linked locale message', () => {
       const spy = sinon.spy(console, 'warn')
-      assert.strictEqual(vm.$i18n.t('message.circular1'), 'Foo Bar Buz Foo @:message.circular2')
+      assert.strictEqual(vm.$i18n.t('message.circular1'), 'Foo Bar Buz @:message.circular1')
       assert(spy.notCalled === false)
       assert(spy.callCount === 1)
       spy.restore()

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -301,11 +301,19 @@ describe('issues', () => {
   })
 
   describe('#247', () => {
-    it('should warn if circular reference in linked locale message', () => {
+    it('should be warned if circular reference in linked locale message', () => {
       const spy = sinon.spy(console, 'warn')
-      vm.$i18n.t('message.circular1')
+      assert.strictEqual(vm.$i18n.t('message.circular1'), 'Foo Bar Buz Foo @:message.circular2')
       assert(spy.notCalled === false)
       assert(spy.callCount === 1)
+      spy.restore()
+    })
+
+    it('should not be warned if same non-circular link used repeatedly', () => {
+      const spy = sinon.spy(console, 'warn')
+      assert.strictEqual(vm.$i18n.t('message.linkTwice'), 'the world: the world')
+      assert(spy.notCalled === true)
+      assert(spy.callCount === 0)
       spy.restore()
     })
   })


### PR DESCRIPTION
Closes #247 

If circular reference found in translation process, it will be warned and the re-visited link key `@:cicular` left as-is in translated message.

Warning log will be
`WARN: '[vue-i18n] Circular reference found. "@:message.circular1" is already visited in the chain of message.circular3 <- message.circular2 <- message.circular1'`