### PR TITLE
Suppress some warnings in production

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -52,7 +52,7 @@ export default {
       }
     })
 
-    if (hasPlaces && children.length > 0 && !everyPlace) {
+    if (process.env.NODE_ENV !== 'production' && hasPlaces && children.length > 0 && !everyPlace) {
       warn('If places prop is set, all child elements must have place prop set.')
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,9 @@ export default class VueI18n {
       const linkPlaceholder: string = link.substr(2).replace(bracketsMatcher, '')
 
       if (visitedLinkStack.includes(linkPlaceholder)) {
-        warn(`Circular reference found. "${link}" is already visited in the chain of ${visitedLinkStack.reverse().join(' <- ')}`)
+        if (process.env.NODE_ENV !== 'production') {
+          warn(`Circular reference found. "${link}" is already visited in the chain of ${visitedLinkStack.reverse().join(' <- ')}`)
+        }
         return ret
       }
       visitedLinkStack.push(linkPlaceholder)
@@ -583,8 +585,10 @@ export default class VueI18n {
 
   _n (value: number, locale: Locale, key: ?string, options: ?NumberFormatOptions): NumberFormatResult {
     /* istanbul ignore if */
-    if (process.env.NODE_ENV !== 'production' && !VueI18n.availabilities.numberFormat) {
-      warn('Cannot format a Number value due to not supported Intl.NumberFormat.')
+    if (!VueI18n.availabilities.numberFormat) {
+      if (process.env.NODE_ENV !== 'production') {
+        warn('Cannot format a Number value due to not supported Intl.NumberFormat.')
+      }
       return ''
     }
 


### PR DESCRIPTION
(no related issue)
This PR complements #438.

I noticed that all `process.env.NODE_ENV !== 'production'` are removed in production mode (`vue-i18n.min.js`). 
Such optimization can make `vue-i18n.min.js` smaller and faster a little.

So, this PR add `process.env.NODE_ENV !== 'production'` to some warning logs, where it seems appropriate.