### PR TITLE
Optimize _link: Remove unnecessary capture group

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const numberFormatKeys = [
   'localeMatcher',
   'formatMatcher'
 ]
-const linkKeyMatcher = /(@:([\w\-_|.]+|\([\w\-_|.]+\)))/g
+const linkKeyMatcher = /(?:@:(?:[\w\-_|.]+|\([\w\-_|.]+\)))/g
 const bracketsMatcher = /[()]/g
 
 export default class VueI18n {


### PR DESCRIPTION
Since `linkKeyMatcher` has `g`lobal flag, match results of its capturing group are not returned in `str.match(linkKeyMatcher)`.

Removing the unnecessary capturing results in https://jsperf.com/capturing-no-captruing-in-global-matches/1
* Firefox 63: 40% faster 
* Chrome 70: 10% faster 

