### PR TITLE
Fix path for locale in the lazyLoading example

### DIFF
--- a/vuepress/guide/lazy-loading.md
+++ b/vuepress/guide/lazy-loading.md
@@ -25,7 +25,7 @@ The `lang` folder is where all of our translation files will reside. The `setup`
 //i18n-setup.js
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import messages from '@/lang'
+import messages from '@/lang/en'
 import axios from 'axios'
 
 Vue.use(VueI18n)


### PR DESCRIPTION
According to the example, you cannot import the folder `lang` but instead should import the default `en` locale.
This could create confusion.