### PR TITLE
fix(index): make silentTranslationWarn work for dates and numbers too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -499,7 +499,7 @@ export default class VueI18n {
 
     // fallback locale
     if (isNull(formats) || isNull(formats[key])) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && !this._silentTranslationWarn) {
         warn(`Fall back to '${fallback}' datetime formats from '${locale} datetime formats.`)
       }
       _locale = fallback
@@ -533,7 +533,7 @@ export default class VueI18n {
     const ret: ?DateTimeFormatResult =
       this._localizeDateTime(value, locale, this.fallbackLocale, this._getDateTimeFormats(), key)
     if (this._isFallbackRoot(ret)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && !this._silentTranslationWarn) {
         warn(`Fall back to datetime localization of root: key '${key}' .`)
       }
       /* istanbul ignore if */
@@ -596,7 +596,7 @@ export default class VueI18n {
 
     // fallback locale
     if (isNull(formats) || isNull(formats[key])) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && !this._silentTranslationWarn) {
         warn(`Fall back to '${fallback}' number formats from '${locale} number formats.`)
       }
       _locale = fallback
@@ -640,7 +640,7 @@ export default class VueI18n {
     const ret: ?NumberFormatResult =
       this._localizeNumber(value, locale, this.fallbackLocale, this._getNumberFormats(), key, options)
     if (this._isFallbackRoot(ret)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && !this._silentTranslationWarn) {
         warn(`Fall back to number localization of root: key '${key}' .`)
       }
       /* istanbul ignore if */


### PR DESCRIPTION
Currently, the `silentTranslationWarn` flag only disables warnings for regular translations, which, I think, is not what people would expect from this option. Even when `silentTranslationWarn` is enabled - warnings for fallback translations for numbers and dates still occur, completely littering the console in some cases.

This fix makes all fallback warnings to vanish (including numbers and dates) upon setting the `silentTranslationWarn` flag, while leaving other (non-fallback) warnings intact.

