### PR TITLE
🐛bugfix(pluralization): inherit pluralization rules ⚠

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -37,6 +37,7 @@ export default {
           options.i18n.formatter = this.$root.$i18n.formatter
           options.i18n.fallbackLocale = this.$root.$i18n.fallbackLocale
           options.i18n.silentTranslationWarn = this.$root.$i18n.silentTranslationWarn
+          options.i18n.pluralizationRules = this.$root.$i18n.pluralizationRules
         }
 
         // init locale messages via custom blocks


### PR DESCRIPTION
Allows pluralization rules to be propagated to children and extended vue components (was only root before).

**Important**: before this fix, child components didn't have any pluralization rules whatsoever. This made custom pluralization only usable on root i18n instances or via $root.$i18n.

Uh. I can't believe I overlooked this earlier... 😒
