### PR TITLE
fixed #478

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ export default class VueI18n {
 
     // Check for the existence of links within the translated string
     if (ret.indexOf('@:') >= 0 || ret.indexOf('@.') >= 0) {
-      ret = this._link(locale, message, ret, host, interpolateMode, values, visitedLinkStack)
+      ret = this._link(locale, message, ret, host, 'raw', values, visitedLinkStack)
     }
 
     return this._render(ret, interpolateMode, values, key)

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -2,6 +2,7 @@ export default {
   en: {
     message: {
       hello: 'the world',
+      helloName: 'Hello {name}',
       hoge: 'hoge',
       empty: '',
       format: {
@@ -10,6 +11,7 @@ export default {
       },
       fallback: 'this is fallback',
       link: '@:message.hello',
+      linkHelloName: '@:message.helloName',
       linkEnd: 'This is a linked translation to @:message.hello',
       linkWithin: 'Isn\'t @:message.hello we live in great?',
       linkMultiple: 'Hello @:message.hoge!, isn\'t @:message.hello great?',

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -12,6 +12,7 @@ export default {
       fallback: 'this is fallback',
       link: '@:message.hello',
       linkHelloName: '@:message.helloName',
+      linkLinkHelloName: '@:message.linkHelloName',
       linkEnd: 'This is a linked translation to @:message.hello',
       linkWithin: 'Isn\'t @:message.hello we live in great?',
       linkMultiple: 'Hello @:message.hoge!, isn\'t @:message.hello great?',

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -672,4 +672,15 @@ describe('issues', () => {
       assert(i18n.t(testPath), 'Hello!')
     })
   })
+
+  describe('#478', () => {
+    it('should be translated', () => {
+      const res = vm.$t('message.linkHelloName', { name: 'World {text}' })
+      assert.strictEqual(res, 'Hello World {text}')
+    })
+    it('should be translated', () => {
+      const res = vm.$t('message.linkHelloName', { name: 'World {text}', text: 'something' })
+      assert.strictEqual(res, 'Hello World {text}')
+    })
+  })
 })

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -682,5 +682,9 @@ describe('issues', () => {
       const res = vm.$t('message.linkHelloName', { name: 'World {text}', text: 'something' })
       assert.strictEqual(res, 'Hello World {text}')
     })
+    it('should be translated', () => {
+      const res = vm.$t('message.linkLinkHelloName', { name: 'World {text}', text: 'something' })
+      assert.strictEqual(res, 'Hello World {text}')
+    })
   })
 })


### PR DESCRIPTION
Essentially, going into link phase triggers additional cycle of interpolation(one outside of linking phase as usual, and one more inside) which leads to weird results.

The fix is pretty simple(and looking at the code, even thought of originally): switch mode to `raw` for the linking phase. 

@kazupon Note:
Prior to this fix, 2 tests already failed on my setup:
- test/unit/datetime.test.js:50 - looks like timezone mismatch
- test/unit/number.test.js:58 - missing space

Not sure if those are known problems or if I should report them. 