### PR TITLE
feat(path): Keypath should parse if sub path contains spaces.

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -122,7 +122,6 @@ function getPathCharType (ch: ?string): string {
     case 0x2D: // -
       return 'ident'
 
-    case 0x20: // Space
     case 0x09: // Tab
     case 0x0A: // Newline
     case 0x0D: // Return

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -105,6 +105,13 @@ describe('basic', () => {
         it('should be translated', () => {
           assert.strictEqual(i18n.t('message.format'), messages.en.message.format)
         })
+
+        it('should be translated if keypath contains spaces', () => {
+          assert.strictEqual(
+            i18n.t('message.Hello {0}', ['kazupon']),
+            'Hello kazupon'
+          )
+        })
       })
 
       describe('array keypath', () => {

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -28,6 +28,7 @@ export default {
       circular2: 'Bar @:message.circular3',
       circular3: 'Buz @:message.circular1',
       linkTwice: '@:message.hello: @:message.hello',
+      'Hello {0}': 'Hello {0}',
       'hyphen-locale': 'hello hyphen',
       '1234': 'Number-based keys are found',
       '1mixedKey': 'Mixed keys are not found.',

--- a/test/unit/path.test.js
+++ b/test/unit/path.test.js
@@ -9,10 +9,27 @@ describe('path', () => {
     })
   })
 
+  describe('whitespace', () => {
+    it('should get value if it contains space 0x20', () => {
+      const val = path.getPathValue({ 'a c': 1 }, 'a c')
+      assert.strictEqual(val, 1)
+    })
+
+    it('should return null if it contains whitespace chars except space 0x20', () => {
+      const val = path.getPathValue({ 'a\tc': 1 }, 'a\tc')
+      assert.strictEqual(val, null)
+    })
+  })
+
   describe('object', () => {
     it('should get path value', () => {
       const val = path.getPathValue({ a: { b: 1 } }, 'a')
       assert.strictEqual(val.b, 1)
+    })
+
+    it('should accept space 0x20 as keypath', () => {
+      const val = path.getPathValue({ a: { 'b c d': 1 } }, 'a.b c d')
+      assert.strictEqual(val, 1)
     })
   })
 


### PR DESCRIPTION
Closes #532 (and its original #502)

I believe "hierarchical key containing space 0x20" like `nested.Hello World` should be OK, since non-hierarchical key like `Hello {0}` can contain space.
https://github.com/kazupon/vue-i18n/blob/70eedb1c80555fed483b6cfe3216bc0a6e5354e4/test/unit/basic.test.js#L92-L97
