### PR TITLE
feat: Implemented new i18n-n functional component

### DIFF
--- a/decls/i18n.js
+++ b/decls/i18n.js
@@ -50,6 +50,15 @@ declare type DateTimeFormatResult = string;
 declare type NumberFormatResult = string;
 declare type MissingHandler = (locale: Locale, key: Path, vm?: any) => string | void;
 
+declare type FormattedNumberPartType = 'currency' | 'decimal' | 'fraction' | 'group' | 'infinity' | 'integer' | 'literal' | 'minusSign' | 'nan' | 'plusSign' | 'percentSign';
+declare type FormattedNumberPart = {
+  type: FormattedNumberPartType,
+  value: string,
+};
+// This array is the same as Intl.NumberFormat.formatToParts() return value:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts#Return_value
+declare type NumberFormatToPartsResult = Array<FormattedNumberPart>;
+
 declare type I18nOptions = {
   locale?: Locale,
   fallbackLocale?: Locale,

--- a/examples/number-formatting/index.html
+++ b/examples/number-formatting/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>number custom formatting</title>
+    <script src="../../node_modules/vue/dist/vue.min.js"></script>
+    <script src="../../dist/vue-i18n.min.js"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.ja,Intl.~locale.en"></script>
+  </head>
+  <body>
+    <div id="app">
+      <select v-model="locale">
+        <option value="en-US">en-US</option>
+        <option value="ja-JP">ja-JP</option>
+      </select>
+      <p>
+        {{ $t('money') }}:
+        <i18n-n :value="money" format="currency">
+          <template slot="decimal" slot-scope="props"><!-- do not render decimal separator --></template>
+          <span slot="fraction" slot-scope="props" style="vertical-align: super">{{ props.fraction }}</span>
+        </i18n-n>
+      </p>
+    </div>
+    <script>
+      var messages = {
+        'en-US': {
+          money: 'Money'
+        },
+        'ja-JP': {
+          money: 'お金'
+        }
+      }
+      var numberFormats = {
+        'en-US': {
+          currency: {
+            style: 'currency', currency: 'USD'
+          }
+        },
+        'ja-JP': {
+          currency: {
+            style: 'currency', currency: 'JPY', currencyDisplay: 'symbol'
+          }
+        }
+      }
+
+      Vue.use(VueI18n)
+
+      var initial = 'ja-JP'
+      var i18n = new VueI18n({
+        locale: initial,
+        messages: messages,
+        numberFormats: numberFormats
+      })
+
+      new Vue({
+        i18n: i18n,
+        data: {
+          locale: initial,
+          money: 1000
+        },
+        watch: {
+          locale: function (val) {
+            this.$i18n.locale = val
+          }
+        },
+        el: '#app'
+      })
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "dist/vue-i18n.min.js",
     "dist/vue-i18n.common.js",
     "dist/vue-i18n.esm.js",
-    "src/*.js",
+    "src/**/*.js",
     "types/*.d.ts",
     "decls"
   ],

--- a/src/components/interpolation.js
+++ b/src/components/interpolation.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { warn } from './util'
+import { warn } from '../util'
 
 export default {
   name: 'i18n',

--- a/src/components/number.js
+++ b/src/components/number.js
@@ -1,0 +1,63 @@
+/* @flow */
+
+import { warn, isObject, numberFormatKeys } from '../util'
+
+export default {
+  name: 'i18n-n',
+  functional: true,
+  props: {
+    tag: {
+      type: String,
+      default: 'span'
+    },
+    value: {
+      type: Number,
+      required: true
+    },
+    format: {
+      type: [String, Object]
+    },
+    locale: {
+      type: String
+    }
+  },
+  render (h: Function, { props, parent, data }: Object) {
+    const i18n = parent.$i18n
+
+    if (!i18n) {
+      if (process.env.NODE_ENV !== 'production') {
+        warn('Cannot find VueI18n instance!')
+      }
+      return null
+    }
+
+    let key: ?string = null
+    let options: ?NumberFormatOptions = null
+
+    if (typeof props.format === 'string') {
+      key = props.format
+    } else if (isObject(props.format)) {
+      if (props.format.key) {
+        key = props.format.key
+      }
+
+      // Filter out number format options only
+      options = Object.keys(props.format).reduce((acc, prop) => {
+        if (numberFormatKeys.includes(prop)) {
+          return Object.assign({}, acc, { [prop]: props.format[prop] })
+        }
+        return acc
+      }, null)
+    }
+
+    const locale: Locale = props.locale || i18n.locale
+    const parts: NumberFormatToPartsResult = i18n._ntp(props.value, locale, key, options)
+
+    const values = parts.map((part, index) => {
+      const slot: ?Function = data.scopedSlots && data.scopedSlots[part.type]
+      return slot ? slot({ [part.type]: part.value, index, parts }) : part.value
+    })
+
+    return h(props.tag, values)
+  }
+}

--- a/src/install.js
+++ b/src/install.js
@@ -1,7 +1,8 @@
 import { warn } from './util'
 import extend from './extend'
 import mixin from './mixin'
-import component from './component'
+import interpolationComponent from './components/interpolation'
+import numberComponent from './components/number'
 import { bind, update, unbind } from './directive'
 
 export let Vue
@@ -26,7 +27,8 @@ export function install (_Vue) {
   extend(Vue)
   Vue.mixin(mixin)
   Vue.directive('t', { bind, update, unbind })
-  Vue.component(component.name, component)
+  Vue.component(interpolationComponent.name, interpolationComponent)
+  Vue.component(numberComponent.name, numberComponent)
 
   // use simple mergeStrategies to prevent i18n instance lose '__proto__'
   const strats = Vue.config.optionMergeStrategies

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,24 @@
 /* @flow */
 
 /**
+ * constants
+ */
+
+export const numberFormatKeys = [
+  'style',
+  'currency',
+  'currencyDisplay',
+  'useGrouping',
+  'minimumIntegerDigits',
+  'minimumFractionDigits',
+  'maximumFractionDigits',
+  'minimumSignificantDigits',
+  'maximumSignificantDigits',
+  'localeMatcher',
+  'formatMatcher'
+]
+
+/**
  * utilities
  */
 

--- a/test/e2e/test/number_formatting.js
+++ b/test/e2e/test/number_formatting.js
@@ -1,0 +1,11 @@
+module.exports = {
+  component: function (browser) {
+    browser
+      .url('http://localhost:8080/examples/number-formatting/')
+      .waitForElementVisible('#app', 1000)
+      .assert.containsText('p', 'お金: ￥1,000')
+      .click('select option[value=en-US]')
+      .assert.attributeContains('p', 'innerHTML', 'Money: $1,000<span style="vertical-align: super">00</span>')
+      .end()
+  }
+}

--- a/test/unit/interpolation.test.js
+++ b/test/unit/interpolation.test.js
@@ -1,4 +1,4 @@
-import Component from '../../src/component'
+import Component from '../../src/components/interpolation'
 
 const messages = {
   en: {

--- a/test/unit/number_component.test.js
+++ b/test/unit/number_component.test.js
@@ -1,0 +1,279 @@
+import numberFormats from './fixture/number'
+
+const desc = VueI18n.availabilities.numberFormat ? describe : describe.skip
+desc('number custom formatting', () => {
+  let i18n
+  let value
+
+  beforeEach(() => {
+    i18n = new VueI18n({
+      locale: 'en-US',
+      fallbackLocale: 'ja-JP',
+      numberFormats
+    })
+    value = 10100
+  })
+
+  describe('basic', () => {
+    it('should be formatted', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', { props: { value } })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.textContent, '10,100')
+      }).then(done)
+    })
+  })
+
+  describe('format', () => {
+    describe('as string property', () => {
+      it('should be formatted', done => {
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n-n', { props: { value, format: 'currency' } })
+          },
+          el: document.createElement('div')
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$el.textContent, '$10,100.00')
+        }).then(done)
+      })
+    })
+
+    describe('as object property', () => {
+      it('should be formatted', done => {
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n-n', { props: { value, format: { key: 'currency' } } })
+          },
+          el: document.createElement('div')
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$el.textContent, '$10,100.00')
+        }).then(done)
+      })
+    })
+  })
+
+  describe('locale', () => {
+    it('should be formatted', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', { props: { value, format: 'currency', locale: 'ja-JP' } })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.textContent, '￥10,100')
+      }).then(done)
+    })
+  })
+
+  describe('tag', () => {
+    it('should be formatted', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', { props: { value, tag: 'p' } })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.outerHTML, '<p>10,100</p>')
+      }).then(done)
+    })
+  })
+
+  describe('explicit options', () => {
+    describe('without key', () => {
+      it('should be formatted', done => {
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n-n', { props: { value, format: { style: 'currency', currency: 'JPY' } } })
+          },
+          el: document.createElement('div')
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$el.textContent, '¥10,100')
+        }).then(done)
+      })
+
+      it('should respect other number options', done => {
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n-n', { props: { value, format: { style: 'currency', currency: 'EUR', currencyDisplay: 'code' } } })
+          },
+          el: document.createElement('div')
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$el.textContent, 'EUR 10,100.00')
+        }).then(done)
+      })
+    })
+
+    describe('with key', () => {
+      it('should be formatted', done => {
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n-n', { props: { value, format: { key: 'currency', currency: 'JPY' } } })
+          },
+          el: document.createElement('div')
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$el.textContent, '¥10,100')
+        }).then(done)
+      })
+
+      it('should respect other number options', done => {
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n-n', { props: { value, format: { key: 'currency', currency: 'EUR', currencyDisplay: 'code' } } })
+          },
+          el: document.createElement('div')
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$el.textContent, 'EUR 10,100.00')
+        }).then(done)
+      })
+    })
+  })
+
+  describe('partial formatting', () => {
+    it('should be formatted', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', {
+            props: { value },
+            scopedSlots: {
+              integer: props => h('span', props.integer),
+              group: props => h('p', props.group)
+            }
+          })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.innerHTML, '<span>10</span><p>,</p><span>100</span>')
+      }).then(done)
+    })
+
+    it('should pass part index as scoped prop', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', {
+            props: { value: 1000000, format: 'currency' },
+            scopedSlots: {
+              currency: props => h('span', new Array(3).fill(props.currency).join('')),
+              group: props => h('p', { staticClass: props.index }, props.group)
+            }
+          })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.innerHTML, '<span>$$$</span>1<p class="2">,</p>000<p class="4">,</p>000.00')
+      }).then(done)
+    })
+
+    it('should pass parts as scoped prop', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', {
+            props: { value: -12 },
+            scopedSlots: {
+              integer: props => h('span', {
+                staticClass: props.parts.find(part => part.type === 'minusSign') ? 'red' : ''
+              }, props.integer)
+            }
+          })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.innerHTML, '-<span class="red">12</span>')
+      }).then(done)
+    })
+
+    it('should ignore non-present scoped slot', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', {
+            props: { value },
+            scopedSlots: {
+              currency: props => h('span', props.currency)
+            }
+          })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.innerHTML, '10,100')
+      }).then(done)
+    })
+
+    it('should ignore default scoped slot', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', {
+            props: { value },
+            scopedSlots: {
+              default: props => h('span', props.integer)
+            }
+          })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.innerHTML, '10,100')
+      }).then(done)
+    })
+  })
+
+  describe('fallback', () => {
+    it('should be formatted', done => {
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n-n', { props: { value: 0.9, format: 'percent' } })
+        },
+        el: document.createElement('div')
+      })
+      nextTick(() => {
+        assert.strictEqual(vm.$el.textContent, '90%')
+      }).then(done)
+    })
+  })
+
+  describe('warnning in render', () => {
+    it('should be warned', () => {
+      const spy = sinon.spy(console, 'warn')
+
+      new Vue({
+        render (h) {
+          return h('i18n-n', { props: { value } })
+        },
+        el: document.createElement('div')
+      })
+      assert(spy.notCalled === false)
+      assert(spy.callCount === 1)
+
+      spy.restore()
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -69,6 +69,14 @@ declare namespace VueI18n {
     [lang: string]: (choice: number, choicesLength: number) => number;
   };
 
+  type FormattedNumberPartType = 'currency' | 'decimal' | 'fraction' | 'group' | 'infinity' | 'integer' | 'literal' | 'minusSign' | 'nan' | 'plusSign' | 'percentSign';
+
+  interface FormattedNumberPart {
+    type: FormattedNumberPartType;
+    value: string;
+  }
+  interface NumberFormatToPartsResult { [index: number]: FormattedNumberPart; }
+
   interface Formatter {
     interpolate(message: string, values: Values | undefined, path: string): (any[] | null);
   }
@@ -115,6 +123,7 @@ export type NumberFormatOptions = VueI18n.NumberFormatOptions;
 export type NumberFormat = VueI18n.NumberFormat;
 export type NumberFormats = VueI18n.NumberFormats;
 export type NumberFormatResult = VueI18n.NumberFormatResult;
+export type NumberFormatToPartsResult = VueI18n.NumberFormatToPartsResult;
 export type Formatter = VueI18n.Formatter;
 export type MissingHandler = VueI18n.MissingHandler;
 export type IntlAvailability = VueI18n.IntlAvailability;

--- a/vuepress/api/README.md
+++ b/vuepress/api/README.md
@@ -89,15 +89,15 @@ Note that you need to guarantee this context equal to component instance in life
   * **Arguments:**
 
     * `{number} value`: required
-    * `{Path | Object} key`: optional
+    * `{Path | Object} format`: optional
     * `{Locale} locale`: optional
   * **Return:** `NumberFormatResult`
 
-Localize the number of `value` with number format of `key`. The number format of `key` need to register to `numberFormats` option of `VueI18n` class, and depend on `locale` option of `VueI18n` constructor. If you will specify `locale` argument, it will have priority over `locale` option of `VueI18n` constructor.
+Localize the number of `value` with number format of `format`. The number format of `format` need to register to `numberFormats` option of `VueI18n` class, and depend on `locale` option of `VueI18n` constructor. If you will specify `locale` argument, it will have priority over `locale` option of `VueI18n` constructor.
 
-If the number format of `key` not exist in `numberFormats` option, fallback to depend on `fallbackLocale` option of `VueI18n` constructor.
+If the number format of `format` not exist in `numberFormats` option, fallback to depend on `fallbackLocale` option of `VueI18n` constructor.
 
-If the second `key` argument specified as an object, it should have the following properties:
+If the second `format` argument specified as an object, it should have the following properties:
 
 * `key {Path}`: optional, number format
 * `locale {Locale}`: optional, locale
@@ -216,7 +216,7 @@ The number formats of localization.
   * **Type:** `Locale[]`
 
   * **Default:** `[]`
-  
+
   * **Examples:** `["en", "ja"]`
 
 The list of available locales in `messages` in lexical order.
@@ -541,14 +541,14 @@ Set the number format of locale.
 
 Merge the registered number formats with the number format of locale.
 
-#### n( value, [key], [locale] )
+#### n( value, [format], [locale] )
 
 > :new: 7.0+
 
   * **Arguments:**
 
     * `{number} value`: required
-    * `{Path | Object} key`: optional
+    * `{Path | Object} format`: optional
     * `{Locale} locale`: optional
   * **Return:** `NumberFormatResult`
 
@@ -648,6 +648,80 @@ new Vue({
 #### See also:
 
 [Component interpolation](../guide/interpolation.md)
+
+### i18n-n functional component
+
+> :new: 8.10+
+
+#### Props:
+
+  * `value {number}`: required, number to format
+  * `format {strig | NumberFormatOptions}`: optional, number format name or object with explicit format options
+  * `locale {Locale}`: optional, locale
+  * `tag {string}`: optional, default `span`
+
+#### Usage:
+
+```html
+<div id="app">
+  <!-- ... -->
+  <i18n-n :value="money" format="currency" tag="label">
+    <span v-slot:currency="slotProps" class="font-weight: bold">{{ slotProps.currency }}<span>
+  </i18n-n>
+  <!-- ... -->
+</div>
+```
+```js
+var numberFormats = {
+  'en-US': {
+    currency: {
+      style: 'currency', currency: 'USD'
+    }
+  },
+  'ja-JP': {
+    currency: {
+      style: 'currency', currency: 'JPY'
+    }
+  }
+}
+
+const i18n = new VueI18n({
+  locale: 'en-US',
+  numberFormats
+})
+new Vue({
+  i18n,
+  data: {
+    money: 10234,
+  }
+}).$mount('#app')
+```
+
+#### Scoped slots
+
+`<i18n-n>` functional component can accept a number of named scoped slots. List of supported slot names is based on [`Intl.NumberFormat.formatToParts()` output types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat/formatToParts):
+
+* `currency`
+* `decimal`
+* `fraction`
+* `group`
+* `infinity`
+* `integer`
+* `literal`
+* `minusSign`
+* `nan`
+* `plusSign`
+* `percentSign`
+
+Each of these named scoped slots will accept three scope parameters:
+
+* `[slotName] {FormattedNumberPartType}`: parameter of the same name as actual slot name (like `integer')
+* `index {Number}`: index of the specific part in the array of number parts
+* `parts {Array}`: array of all formatted number parts
+
+#### See also:
+
+[Number custom formatting](../guide/number.md#custom-formatting)
 
 ## Special Attributes
 

--- a/vuepress/guide/number.md
+++ b/vuepress/guide/number.md
@@ -23,9 +23,9 @@ const numberFormats = {
 }
 ```
 
-As the Above, You can define the number format with named (e.g. `currency`, etc), and you need to use [the options with ECMA-402 Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
+As the above, you can define the number format with name (e.g. `currency`, etc), and you need to use [the options with ECMA-402 Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
 
-After that like the locale messages, You need to specify the `numberFormats` option of `VueI18n` constructor:
+After that like the locale messages, you need to specify the `numberFormats` option of `VueI18n` constructor:
 
 ```js
 const i18n = new VueI18n({
@@ -55,3 +55,74 @@ Output the below:
   <p>￥100</p>
 </div>
 ```
+
+## Custom formatting
+
+:::tip Support Version
+:new: 8.10+
+:::
+
+`$n` method returns resulting string with fully formatted number, which can only be used as a whole. In situations when you need to style some part of the formatted number (like fraction digits), `$n` is not enough. In such cases `<i18n-n>` functional component will be of help.
+
+With a minimum set of properties, `<i18n-n>` generates the same output as `$n`, wrapped into configured DOM element.
+
+The following template:
+
+```html
+<div id="app">
+  <i18n-n :value="100"></i18n-n>
+  <i18n-n :value="100" format="currency"></i18n-n>
+  <i18n-n :value="100" format="currency" locale="ja-JP"></i18n-n>
+</div>
+```
+
+will produce output below:
+
+```html
+<div id="app">
+  <span>100</span>
+  <span>$100.00</span>
+  <span>￥100</span>
+</div>
+```
+
+But real power of this component comes into play when it is used with [scoped slots](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots).
+
+Lets say there is requirement to render integer part of the number with a bolder font. This can be achieved by specifying `integer` scoped slot element:
+
+```html
+<i18n-n :value="100" format="currency">
+  <span v-slot:integer="slotProps" styles="font-weight: bold">{{ slotProps.integer }}</span>
+</i18n-n>
+```
+
+Template above will result in the following HTML:
+
+```html
+<span>$<span styles="font-weight: bold">100</span>.00</span>
+```
+
+It is possible to specify multiple scoped slots at the same time:
+
+```html
+<i18n-n :value="1234" :format="{ key: 'currency', currency: 'EUR' }">
+  <span v-slot:integer="slotProps" styles="font-weight: bold">{{ slotProps.integer }}</span>
+  <span v-slot:group="slotProps" styles="font-weight: bold">{{ slotProps.group }}</span>
+  <span v-slot:fraction="slotProps" styles="font-size: small">{{ slotProps.fraction }}</span>
+</i18n-n>
+```
+
+(this resulting HTML was formatted for better readability)
+
+```html
+<span>
+  €
+  <span styles="font-weight: bold">1</span>
+  <span styles="font-weight: bold">,</span>
+  <span styles="font-weight: bold">234</span>
+  .
+  <span styles="font-size: small">00</span>
+</span>
+```
+
+Full list of the supported scoped slots as well as other `<i18n-n>` properties can be found [on API page](../api/readme.md#i18n-n-functional-component).


### PR DESCRIPTION
This PR implements feature proposal from #539.

@kazupon It was not possible to have `key` property for the `<i18n-n>` component as it is reserved keyword in Vue itself. I defined it as `format` property instead, and renamed `key` to `format` inside documentation for `n()` and `$n()` methods for consistency. Hope it is ok with you (no code changes, it is only documentation update).