### PR TITLE
fix: SSR memory leak 

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -28,8 +28,6 @@ export default {
         }
         this._i18n = options.i18n
         this._i18nWatcher = this._i18n.watchI18nData()
-        this._i18n.subscribeDataChanging(this)
-        this._subscribing = true
       } else if (isPlainObject(options.i18n)) {
         // component local i18n
         if (this.$root && this.$root.$i18n && this.$root.$i18n instanceof VueI18n) {
@@ -59,8 +57,6 @@ export default {
 
         this._i18n = new VueI18n(options.i18n)
         this._i18nWatcher = this._i18n.watchI18nData()
-        this._i18n.subscribeDataChanging(this)
-        this._subscribing = true
 
         if (options.i18n.sync === undefined || !!options.i18n.sync) {
           this._localeWatcher = this.$i18n.watchLocale()
@@ -73,11 +69,33 @@ export default {
     } else if (this.$root && this.$root.$i18n && this.$root.$i18n instanceof VueI18n) {
       // root i18n
       this._i18n = this.$root.$i18n
-      this._i18n.subscribeDataChanging(this)
-      this._subscribing = true
     } else if (options.parent && options.parent.$i18n && options.parent.$i18n instanceof VueI18n) {
       // parent i18n
       this._i18n = options.parent.$i18n
+    }
+  },
+
+  beforeMount (): void {
+    const options: any = this.$options
+    options.i18n = options.i18n || (options.__i18n ? {} : null)
+
+    if (options.i18n) {
+      if (options.i18n instanceof VueI18n) {
+        // init locale messages via custom blocks
+        this._i18n.subscribeDataChanging(this)
+        this._subscribing = true
+      } else if (isPlainObject(options.i18n)) {
+        this._i18n.subscribeDataChanging(this)
+        this._subscribing = true
+      } else {
+        if (process.env.NODE_ENV !== 'production') {
+          warn(`Cannot be interpreted 'i18n' option.`)
+        }
+      }
+    } else if (this.$root && this.$root.$i18n && this.$root.$i18n instanceof VueI18n) {
+      this._i18n.subscribeDataChanging(this)
+      this._subscribing = true
+    } else if (options.parent && options.parent.$i18n && options.parent.$i18n instanceof VueI18n) {
       this._i18n.subscribeDataChanging(this)
       this._subscribing = true
     }


### PR DESCRIPTION
by moving `subscribeDataChanging` calls into `beforeMount` according to 
https://ssr.vuejs.org/guide/universal.html#component-lifecycle-hooks

> However, because the destroy hooks will not be called during SSR, the timers will stay around forever. To avoid this, move your side-effect code into beforeMount or mounted instead.

Signed-off-by: Simon Dittlmann <131621+Pindar@users.noreply.github.com>

