### PR TITLE
VueI18n factory

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -9,6 +9,9 @@ export default {
     options.i18n = options.i18n || (options.__i18n ? {} : null)
 
     if (options.i18n) {
+      if (typeof options.i18n === 'function') {
+        options.i18n = options.i18n()
+      }
       if (options.i18n instanceof VueI18n) {
         // init locale messages via custom blocks
         if (options.__i18n) {

--- a/test/unit/factory.test.js
+++ b/test/unit/factory.test.js
@@ -32,7 +32,7 @@ describe('i18n factory', () => {
 
   beforeEach(done => {
     FactoryBasedComponent = Vue.extend({
-      i18n: i18nFactory, // normal i18n instance injection
+      i18n: i18nFactory, // i18n factory injection
       render (h) {
         return h('div', {}, [
           h('p', { ref: 'who' }, [this.$t('who')])

--- a/test/unit/factory.test.js
+++ b/test/unit/factory.test.js
@@ -1,0 +1,63 @@
+describe('i18n factory', () => {
+  let InstanceBasedComponent, FactoryBasedComponent
+  const messages = {
+    'en-US': {
+      who: 'root',
+      fallback: 'fallback'
+    },
+    'ja-JP': {
+      who: 'ルート',
+      fallback: 'フォールバック'
+    }
+  }
+
+  const i18nFactory = () => new VueI18n({
+    locale: 'en-US',
+    messages
+  })
+
+  const i18n = i18nFactory()
+
+  beforeEach(done => {
+    InstanceBasedComponent = Vue.extend({
+      i18n, // normal i18n instance injection
+      render (h) {
+        return h('div', {}, [
+          h('p', { ref: 'who' }, [this.$t('who')])
+        ])
+      }
+    })
+    done()
+  })
+
+  beforeEach(done => {
+    FactoryBasedComponent = Vue.extend({
+      i18n: i18nFactory, // normal i18n instance injection
+      render (h) {
+        return h('div', {}, [
+          h('p', { ref: 'who' }, [this.$t('who')])
+        ])
+      }
+    })
+    done()
+  })
+
+  it('should initialize a VueI18n factory', () => {
+    const vm = new FactoryBasedComponent()
+    assert(vm.$i18n instanceof VueI18n)
+  })
+
+  it('should have different VueI18n instances on different components instances', () => {
+    const vm = new FactoryBasedComponent()
+    const vm2 = new FactoryBasedComponent()
+    assert.notEqual(vm.$i18n, vm2.$i18n)
+  })
+
+  it('should behave normally if factory is not provided', () => {
+    const vm = new InstanceBasedComponent()
+    const vm2 = new InstanceBasedComponent()
+    assert(vm.$i18n instanceof VueI18n)
+    assert(vm2.$i18n instanceof VueI18n)
+    assert.strictEqual(vm.$i18n, vm2.$i18n)
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -213,12 +213,19 @@ declare module 'vue/types/vue' {
 }
 
 declare module 'vue/types/options' {
+
+  type VueI18nFactory = () => {
+    messages?: VueI18n.LocaleMessages;
+    dateTimeFormats?: VueI18n.DateTimeFormats;
+    numberFormats?: VueI18n.NumberFormats;
+  }
+
   interface ComponentOptions<V extends Vue> {
     i18n?: {
       messages?: VueI18n.LocaleMessages;
       dateTimeFormats?: VueI18n.DateTimeFormats;
       numberFormats?: VueI18n.NumberFormats;
-    };
+    } | VueI18nFactory;
   }
 }
 

--- a/vuepress/api/README.md
+++ b/vuepress/api/README.md
@@ -10,9 +10,10 @@ sidebar: auto
 
 #### i18n
 
-  * **Type:** `I18nOptions`
+  * **Type:** `I18nOptions | VueI18nFactory`
 
 Component based localization option.
+A VueI18n factory can be provided.
 
   * **See also:** `VueI18n` class constructor options
 


### PR DESCRIPTION
In some situations (for ex. micro-frontend environments where vue apps are wrapped in web-components) it would be good to have different VueI18n instances when a wrapped vue app is destroyed and recreated (since normally the VueI18n is created before and referenced in Vue component options).