### PR TITLE
define locale on the i18n instance for sfc

### DIFF
--- a/vuepress/guide/sfc.md
+++ b/vuepress/guide/sfc.md
@@ -32,7 +32,10 @@ The following in [single file components example](https://github.com/kazupon/vue
 <script>
 export default {
   name: 'app',
-  data () { return { locale: 'en' } },
+  data () {
+    this.$i18n.locale = 'en';
+    return { locale: 'en' } 
+  },
   watch: {
     locale (val) {
       this.$i18n.locale = val


### PR DESCRIPTION
As mentioned in this #593 issue [comment](https://github.com/kazupon/vue-i18n/issues/593#issuecomment-503662814) the locale must also be defined in the data function object for the translations to load

