### PR TITLE
Do not remove _i18n property as it can be needed after beforeDestroy()

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -108,8 +108,6 @@ export default {
   },
 
   beforeDestroy (): void {
-    if (!this._i18n) { return }
-
     const self = this
     this.$nextTick(() => {
       if (self._subscribing) {
@@ -127,8 +125,6 @@ export default {
         self._localeWatcher()
         delete self._localeWatcher
       }
-
-      self._i18n = null
     })
   }
 }

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -135,8 +135,6 @@ describe('component translation', () => {
       assert.strictEqual(subChild2.textContent, 'sub-child2')
 
       vm.$destroy()
-    }).then(() => {
-      assert(vm.$i18n === null)
     }).then(done)
   })
 })

--- a/test/unit/mixin.test.js
+++ b/test/unit/mixin.test.js
@@ -19,8 +19,24 @@ describe('mixin', () => {
   describe('beforeDestroy', () => {
     describe('not assign VueI18n instance', () => {
       it('should be succeeded', () => {
-        assert(mixin.beforeDestroy() === undefined)
+        let nextTickCalled = 0
+        const that = {
+          beforeDestroy: mixin.beforeDestroy,
+          $nextTick: () => nextTickCalled++
+        }
+        const result = that.beforeDestroy()
+        assert.equal(result, undefined)
+        assert.equal(nextTickCalled, 1)
       })
+    })
+    it('this._i18n should still be available after beforeDestroy', () => {
+      const that = {
+        _i18n: 1,
+        beforeDestroy: mixin.beforeDestroy,
+        $nextTick: () => {}
+      }
+      that.beforeDestroy()
+      assert.ok(that._i18n)
     })
   })
 })


### PR DESCRIPTION
In some circumstances a long running method call can still be running after a component is removed from the DOM. This causes beforeDestroy() to be called.

If this long running method now calls this.$t or similar that leads to errors as the further down called this._i18n is null. This._i18n needs to be available even after beforeDestroy() is being called.

fixes #184

