### PR TITLE
Fix component interpolation with empty text nodes

### DIFF
--- a/src/components/interpolation.js
+++ b/src/components/interpolation.js
@@ -54,6 +54,12 @@ function onlyHasDefaultPlace (params) {
 
 function useLegacyPlaces (children, places) {
   const params = places ? createParamsFromPlaces(places) : {}
+
+  // Filter empty text nodes
+  children = (children || []).filter(child => {
+    return child.tag || (child.text = child.text.trim())
+  })
+
   if (!children) { return params }
 
   const everyPlace = children.every(vnodeHasPlaceAttribute)

--- a/src/components/interpolation.js
+++ b/src/components/interpolation.js
@@ -59,7 +59,7 @@ function useLegacyPlaces (children, places) {
 
   // Filter empty text nodes
   children = children.filter(child => {
-    return child.tag || (child.text = child.text.trim())
+    return child.tag || child.text.trim() !== ''
   })
 
   const everyPlace = children.every(vnodeHasPlaceAttribute)

--- a/src/components/interpolation.js
+++ b/src/components/interpolation.js
@@ -54,13 +54,13 @@ function onlyHasDefaultPlace (params) {
 
 function useLegacyPlaces (children, places) {
   const params = places ? createParamsFromPlaces(places) : {}
+  
+  if (!children) { return params }
 
   // Filter empty text nodes
-  children = (children || []).filter(child => {
+  children = children.filter(child => {
     return child.tag || (child.text = child.text.trim())
   })
-
-  if (!children) { return params }
 
   const everyPlace = children.every(vnodeHasPlaceAttribute)
   if (process.env.NODE_ENV !== 'production' && everyPlace) {

--- a/test/unit/interpolation.test.js
+++ b/test/unit/interpolation.test.js
@@ -80,6 +80,25 @@ describe('component interpolation', () => {
       })
     })
 
+    describe('empty text node between components', () => {
+      it('should be interpolated', done => {
+        const el = document.createElement('div')
+        const vm = new Vue({
+          i18n,
+          render (h) {
+            return h('i18n', { props: { path: 'primitive' } }, [
+              h('p', ['1']),
+              this._v(''),
+              h('p', ['2'])
+            ])
+          }
+        }).$mount(el)
+        nextTick(() => {
+          assert.strictEqual(vm.$el.innerHTML, 'one: <p>1</p>, two: <p>2</p>')
+        }).then(done)
+      })
+    })
+
     describe('components', () => {
       it('should be interpolated', done => {
         const el = document.createElement('div')

--- a/test/unit/interpolation.test.js
+++ b/test/unit/interpolation.test.js
@@ -81,7 +81,7 @@ describe('component interpolation', () => {
     })
 
     describe('empty text node between components', () => {
-      it('should be interpolated', done => {
+      it('should NOT be interpolated', done => {
         const el = document.createElement('div')
         const vm = new Vue({
           i18n,


### PR DESCRIPTION
<!--
Thank you for contributing! Please carefully read the following before opening your issue.

Got a question?
===============
The issue list of this repo is **exclusively** for bug reports and feature requests. For simple questions, please use the following resources:

- Read the docs: https://github.com/kazupon/vue-i18n/blob/dev/README.md
- Ask on the forums: http://forum.vuejs.org/
- Look for/ask questions on stack overflow: https://stackoverflow.com/questions/ask?tags=vue-i18n

Reporting a bug?
================
- Try to search for your issue, it may have already been answered or even fixed in the development branch.

- Check if the issue is reproducible with the latest stable version of Vue. If you are using a pre-release, please indicate the specific version you are using.

- It is recommended that you make a JSFiddle/JSBin/Codepen to demonstrate your issue. You could start with [this template](https://jsfiddle.net/kazupon/rn724baz/3/) that already includes the latest version of Vue & Vue-i18n.

- For bugs that involves build setups, you can create a reproduction repository with steps in the README.

- If your issue is resolved but still open, don’t hesitate to close it. In case you found a solution by yourself, it could be helpful to explain how you fixed it.

Have a feature request?
=======================
Remove the template from below and provide thoughtful commentary *and code samples* on what this feature means for your product. What will it allow you to do that you can't do today? How will it make current work-arounds straightforward? What potential bugs and edge cases does it help to avoid? etc. Please keep it product-centric.
-->

<!-- BUG REPORT TEMPLATE -->
### vue & vue-i18n version
2.6.10, 8.14.0

### Reproduction Link
<!-- A minimal JSBin, JSFiddle, Codepen, or a GitHub reprository that can reproduce the bug. -->
https://jsfiddle.net/sgjdvu3k/1/ - current not working version
https://jsfiddle.net/41fwghpj/ - previous vue-i18n version

### Steps to reproduce
Open provided js fiddle.
After update to v8.14.0 when using i18n component only first child element is interpolated.

### What is Expected?
All child component should be rendered.

### What is actually happening?
Only first child is rendered.

### Investigation
#685 broke this functionality. After checking generated render function I saw that there is empty text node generated between components. Old code filtered empty text nodes out but there is no filtering now.