### PR TITLE
[Guideline] Describe English as a shared language inside this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@
 - [Pull Request Guidelines](#pull-request-guidelines)
 - [Development Setup](#development-setup)
 
+## General Guidelines
+
+Thanks for understanding that English is used as a shared language in this repository.
+Maintainers do not use machine translation to avoid miscommunication due to error in translation.
+If description of issue / PR are written in non-English languages, those may be closed.
+
+It is ofcourse fine to use non-English language, when you open a PR to translate documents and communicates with other users in same language.
+
 ## Issue Reporting Guidelines
 
 - The issue list of this repo is **exclusively** for bug reports and feature requests. Non-conforming issues will be closed immediately.


### PR DESCRIPTION
Not a small number of issues/PRs are written in non-English languages,.
It is very happy 😃 because it is definitely a sign that vue-i18n is expanding its user community across the world 🌐.

However, from maintenancing POV, non-English languages (and machine translation for them) for communication could be a source of confusing.
We maintainers and many contributors need a base for communication, a shared language 🤝.
So I think we should indicate that English is shared language inside this repository, and ask users to follow this guideline.
