### PR TITLE
Fix spelling in guide files

### DIFF
--- a/vuepress/guide/component.md
+++ b/vuepress/guide/component.md
@@ -2,7 +2,7 @@
 
 In general, locale info (e.g. `locale`,`messages`, etc) is set as constructor option of `VueI18n` instance and it sets `i18n` option as root Vue instance.
 
-Therefore you can globally translate with using `$t` or `$tc` in the root Vue instance and any composed component. You can also manage locale info for each component separately, which might be more convenient due to Vue components oriented design.
+Therefore you can globally translate using `$t` or `$tc` in the root Vue instance and any composed component. You can also manage locale info for each component separately, which might be more convenient due to Vue components oriented design.
 
 Component based localization example:
 
@@ -51,7 +51,7 @@ new Vue({
 
 Template:
 
-    
+
 ```html
 <div id="app">
   <p>{{ $t("message.hello") }}</p>
@@ -73,7 +73,7 @@ Outputs the following:
 
 As in the example above, if the component doesn't have the locale message, it falls back to globally defined localization info. The component uses the language set in the root instance (in the above example: `locale: 'ja'`).
 
-Note, that by default falling back to root locale generates two warnings in the console:
+Note that, by default, falling back to root locale generates two warnings in the console:
 
 ```console
 [vue-i18n] Value of key 'message.greeting' is not a string!
@@ -82,7 +82,7 @@ Note, that by default falling back to root locale generates two warnings in the 
 
 To suppress these warnings (while keeping those which warn of the total absence of translation for the given key) set `silentFallbackWarn: true` when initializing the `VueI18n` instance.
 
-If you hope localize in the component locale, you can realize with `sync: false` and `locale` in `i18n` option.
+If you want to localize using the component locale, you can do that with `sync: false` and `locale` in the `i18n` option.
 
 
 ## Shared locale messages for components
@@ -91,7 +91,7 @@ Sometimes you may want to import shared locale messages for certain components, 
 
 You can use `sharedMessages` options of `i18n`.
 
-Common Locale Messasge example:
+Common Locale Message example:
 ```js
 export default {
   en: {
@@ -137,7 +137,7 @@ If `sharedMessages` option is specified along with the `messages` option, those 
 
 ## Translation in functional component
 
-When using a functional component, all the data (including props, children, slots, parent, etc.) is passed through `context` containing the attributes, and it doesn't recognize the `this` scope, so when using the vue-i18n on functional components, you must refer to `$t` as `parent.$t`, check the example below:
+When using a functional component, all data (including props, children, slots, parent, etc.) is passed through the `context` containing the attributes, and it doesn't recognize the `this` scope, so when using the vue-i18n on functional components, you must refer to `$t` as `parent.$t`, check the example below:
 
 ```html
 ...

--- a/vuepress/guide/datetime.md
+++ b/vuepress/guide/datetime.md
@@ -31,9 +31,9 @@ const dateTimeFormats = {
 }
 ```
 
-As the Above, You can define the datetime format with named (e.g. `short`, `long`, etc), and you need to use [the options with ECMA-402 Intl.DateTimeFormat](http://www.ecma-international.org/ecma-402/2.0/#sec-intl-datetimeformat-constructor)
+As seen above, you can define named datetime format (e.g. `short`, `long`, etc), and you need to use [the options with ECMA-402 Intl.DateTimeFormat](http://www.ecma-international.org/ecma-402/2.0/#sec-intl-datetimeformat-constructor)
 
-After that like the locale messages, You need to specify the `dateTimeFormats` option of `VueI18n` constructor:
+After that, when using the locale messages, you need to specify the `dateTimeFormats` option of the `VueI18n` constructor:
 
 ```js
 const i18n = new VueI18n({

--- a/vuepress/guide/directive.md
+++ b/vuepress/guide/directive.md
@@ -4,7 +4,7 @@
 :new: 7.3+
 :::
 
-You can translate not only with `v-t` custom directive, but also with `$t`
+You can translate not only with `v-t` custom directive, but also with the `$t`
 method.
 
 ## String syntax
@@ -94,9 +94,9 @@ Outputs:
 :new: 8.7+
 :::
 
-When `v-t` directive is applied to an element inside [`<transition>` component](https://vuejs.org/v2/api/#transition), you may notice that translated message will disappear during the transition. This behavior is related to the nature of the `<transition>` component implementation – all directives in disappearing element inside `<transition>` component will be destroyed **before transition starts**. This behavior may result in content flickering on short animations, but most noticable on long transitions.
+When `v-t` directive is applied to an element inside [`<transition>` component](https://vuejs.org/v2/api/#transition), you may notice that the translated message disappears during the transition. This behavior is related to the nature of the `<transition>` component implementation – all directives in the disappearing element inside the `<transition>` component will be destroyed **before the transition starts**. This behavior may result in content flickering on short animations, but is most noticable on long transitions.
 
-To make sure directive content will stay un-touched during transition just add [`.preserve` modifier](../api/#v-t) to `v-t` directive defintion.
+To make sure directive content stays un-touched during a transition, just add the [`.preserve` modifier](../api/#v-t) to the `v-t` directive defintion.
 
 Javascript:
 
@@ -123,7 +123,7 @@ Templates:
 </div>
 ```
 
-It is also possible to set global setting on `VueI18n` instance itself, which will have effect on all `v-t` directives without modifier.
+It is also possible to set global settings on the `VueI18n` instance itself, which will affect all `v-t` directives without modifier.
 
 Javascript:
 
@@ -157,7 +157,7 @@ About the above examples, see the [example](https://github.com/kazupon/vue-i18n/
 
 ### `$t`
 
-`$t` is extended Vue instance method. It has the following pros and cons:
+`$t` is an extended Vue instance method. It has the following pros and cons:
 
 #### Pros
 
@@ -165,7 +165,7 @@ You can **flexibly** use mustash syntax `{{}}` in templates and also computed pr
 
 #### Cons
 
-`$t` is executed **every time** when re-render occurs, so it does have a translation costs.
+`$t` is executed **every time** when re-render occurs, so it does have translation costs.
 
 ### `v-t`
 
@@ -179,4 +179,4 @@ Therefore it's possible to make **more performance optimizations**.
 
 #### Cons
 
-`v-t` can not be flexibly used like `$t`, it's rather **complex**. The translated content with `v-t` is inserted into the `textContent` of the element. Also, when you use server-side rendering, you need to set the [custom directive](https://github.com/kazupon/vue-i18n-extensions#directive-v-t-custom-directive-for-server-side) to `directives` option of the `createRenderer` function.
+`v-t` cannot be flexibly used like `$t`, it's rather **complex**. The translated content with `v-t` is inserted into the `textContent` of the element. Also, when you use server-side rendering, you need to set the [custom directive](https://github.com/kazupon/vue-i18n-extensions#directive-v-t-custom-directive-for-server-side) to `directives` option of the `createRenderer` function.

--- a/vuepress/guide/fallback.md
+++ b/vuepress/guide/fallback.md
@@ -1,6 +1,6 @@
 # Fallback localization
 
-The following locale messages that don't exist `message` key in `ja` locale:
+The following locale messages with a `message` key that doesn't exist in the `ja` locale:
 
 ```js
 const messages = {
@@ -12,7 +12,7 @@ const messages = {
 }
 ```
 
-When specify the `fallbackLocale` option to VueI18n constructor option, `message` key is localized with `en` locale key:
+When specifying the `fallbackLocale` option in the VueI18n constructor option, `message` key is localized with `en` locale key:
 
 ```js
 const i18n = new VueI18n({
@@ -20,21 +20,21 @@ const i18n = new VueI18n({
   fallbackLocale: 'en',
   messages
 })
-```    
+```
 
-Template the below:
+Template:
 
-```html     
+```html
 <p>{{ $t('message') }}</p>
 ```
 
-Output the below:
+Output:
 
 ```html
 <p>hello world</p>
 ```
 
-Note, that by default falling back to `fallbackLocale` generates two console warnings:
+Note that, by default, falling back to `fallbackLocale` generates two console warnings:
 
 ```console
 [vue-i18n] Value of key 'message' is not a string!
@@ -79,14 +79,14 @@ const i18n = new VueI18n({
 })
 ```
 
-When you template the below:
+When the template is as below:
 
 ```html
 <p>{{ $t('Hello {name}', { name: 'John' }}) }}</p>
 <p>{{ $t('The weather today is {condition}!', { condition: 'sunny' }) }}</p>
 ```
 
-The following will be the output:
+The following will be output:
 
 ```html
 <p>Здравствуйте John</p>

--- a/vuepress/guide/formatting.md
+++ b/vuepress/guide/formatting.md
@@ -2,10 +2,9 @@
 
 ## Named formatting
 
-Locale messages the below:
+Locale messages:
 
-    
-```js 
+```js
 const messages = {
   en: {
     message: {
@@ -15,23 +14,23 @@ const messages = {
 }
 ```
 
-Template the below:
+Template:
 
-```html   
+```html
 <p>{{ $t('message.hello', { msg: 'hello' }) }}</p>
 ```
 
-Output the below:
+Output:
 
-```html 
+```html
 <p>hello world</p>
 ```
 
 ## List formatting
 
-Locale messages the below:
+Locale messages:
 
-```js 
+```js
 const messages = {
   en: {
     message: {
@@ -41,37 +40,36 @@ const messages = {
 }
 ```
 
-Template the below:
+Template:
 
-```html 
+```html
 <p>{{ $t('message.hello', ['hello']) }}</p>
 ```
 
-Output the below:
+Output:
 
-```html 
+```html
 <p>hello world</p>
 ```
 
-List formatting also accepts array-like object:
+List formatting also accepts array-like objects:
 
-    
-```html  
+```html
 <p>{{ $t('message.hello', {'0': 'hello'}) }}</p>
 ```
 
-Output the below:
+Output:
 
-```html  
+```html
 <p>hello world</p>
-```    
+```
 
 ## HTML formatting
 
 :::warning Notice
-:warning: Dynamically localization arbitrary HTML on your website can be very dangerous because it can easily lead to XSS vulnerabilities. Only use HTML interpolation on trusted content and never on user-provided content. 
+:warning: Dynamically localizing arbitrary HTML on your website can be very dangerous because it can easily lead to XSS vulnerabilities. Only use HTML interpolation on trusted content and never on user-provided content.
 
-We recommended that use [component interpolation](interpolation.md) feature.  
+We recommended using the [component interpolation](interpolation.md) feature.
 :::
 
 :::warning Notice
@@ -80,10 +78,10 @@ We recommended that use [component interpolation](interpolation.md) feature.
 You can control the use of HTML formatting. see the detail  `warnHtmlInMessage` constructor option and property API.
 :::
 
-In some cases you might want to rendered your translation as an HTML message and not a static string.
+In some cases you might want to render your translation as an HTML message and not a static string.
 
-    
-```js  
+
+```js
 const messages = {
   en: {
     message: {
@@ -93,16 +91,16 @@ const messages = {
 }
 ```
 
-Template the below:
+Template:
 
-    
-```html    
+
+```html
 <p v-html="$t('message.hello')"></p>
 ```
 
-Output the below (instead of the message pre formatted)
+Output (instead of the pre-formatted message )
 
-    
+
 ```html
 <p>hello
 <!--<br> exists but is rendered as html and not a string-->
@@ -112,9 +110,9 @@ world</p>
 
 ## Support ruby on rails i18n format
 
-Locale messages the below:
+Locale messages:
 
-```js    
+```js
 const messages = {
   en: {
     message: {
@@ -124,33 +122,33 @@ const messages = {
 }
 ```
 
-Template the below:
+Template:
 
-```html 
+```html
 <p>{{ $t('message.hello', { msg: 'hello' }) }}</p>
 ```
 
-Output the below:
+Output:
 
-```html 
+```html
 <p>hello world</p>
 ```
 
 ## Custom formatting
 
-Sometimes, you maybe need to translate with custom formatting (e.g. [ICU message syntax](http://userguide.icu-project.org/formatparse/messages)).
+Sometimes, you may need to translate using custom formatting (e.g. [ICU message syntax](http://userguide.icu-project.org/formatparse/messages)).
 
-You can realize with custom formatter that implement [Formatter Interface](https://github.com/kazupon/vue-i18n/blob/dev/decls/i18n.js#L41-L43).
+You can do that with a custom formatter that implements the [Formatter Interface](https://github.com/kazupon/vue-i18n/blob/dev/decls/i18n.js#L41-L43).
 
 The following custom formatter with ES2015 class syntax:
 
-```js 
+```js
 // Custom Formatter implementation
 class CustomFormatter {
      constructor (options) {
        // ...
      }
-    
+
      //
      // interpolate
      //
@@ -163,8 +161,8 @@ class CustomFormatter {
      // @param {Object | Array} values
      //   values of `message` interpolation.
      //   passed values with `$t`, `$tc` and `i18n` functional component.
-     //   e.g. 
-     //   - $t('hello', { name: 'kazupon' }) -> passed values: Object `{ name: 'kazupon' }` 
+     //   e.g.
+     //   - $t('hello', { name: 'kazupon' }) -> passed values: Object `{ name: 'kazupon' }`
      //   - $t('hello', ['kazupon']) -> passed values: Array `['kazupon']`
      //   - `i18n` functional component (component interpolation)
      //     <i18n path="hello">
@@ -178,16 +176,16 @@ class CustomFormatter {
      //   interpolated values. you need to return the following:
      //   - array of string, when is using `$t` or `$tc`.
      //   - array included VNode object, when is using `i18n` functional component.
-     // 
+     //
      interpolate (message, values) {
        // implement interpolation logic here
        // ...
-    
+
        // return the interpolated array
        return ['resolved message string']
      }
 }
-    
+
 // register with `formatter` option
 const i18n = new VueI18n({
   locale: 'en-US',
@@ -199,7 +197,7 @@ const i18n = new VueI18n({
     // ...
   }
 })
-    
+
 // Run!
 new Vue({ i18n }).$mount('#app')
 ```

--- a/vuepress/guide/interpolation.md
+++ b/vuepress/guide/interpolation.md
@@ -6,13 +6,13 @@
 :new: 7.0+
 :::
 
-Sometimes, we need to localize with locale message that was included HTML tag or component. For example:
+Sometimes, we need to localize with a locale message that was included in a HTML tag or component. For example:
 
 ```html
 <p>I accept xxx <a href="/term">Terms of Service Agreement</a></p>
 ```
 
-In the above message, if you use with `$t`, probably you may try to compose the following locale messages:
+In the above message, if you use `$t`, you will probably try to compose the following locale messages:
 
 ```js
 const messages = {
@@ -23,22 +23,22 @@ const messages = {
 }
 ```
 
-And in the following, you may try to implement in template:
+And your localized template may look like this:
 
 ```html
 <p>{{ $t('term1') }}<a href="/term">{{ $t('term2') }}</a></p>
 ```
 
-output:
+Output:
 
 ```html
 <p>I accept xxx <a href="/term">Terms of Service Agreement</a></p>
 ```
 
-This is very cumbersome, and if you configure the `<a>` tag in a locale message, there is a possibility XSS vulnerabilities due to localize with
+This is very cumbersome, and if you configure the `<a>` tag in a locale message, there is a possibility of XSS vulnerabilities due to localizing with
 `v-html="$t('term')"`.
 
-You can avoid it with using `i18n` functional component. For example:
+You can avoid it using the `i18n` functional component. For example:
 
 ```html
 <div id="app">
@@ -87,13 +87,13 @@ the following output:
 
 About the above example, see the [example](https://github.com/kazupon/vue-i18n/tree/dev/examples/interpolation/places)
 
-The children of `i18n` functional component is interpolated with locale message of `path` prop. In the above example, 
+The children of `i18n` functional component are interpolated with locale message of `path` prop. In the above example,
 :::v-pre
 `<a :href="url" target="_blank">{{ $t('tos') }}</a>`
 :::
 is interpolated with `term` locale message.
 
-In above example, the component interpolation follows the **list formatting**.  The children of `i18n` functional component are interpolated by their orders of appearance.
+In the above example, the component interpolation follows the **list formatting**.  The children of `i18n` functional component are interpolated by their order of appearance.
 
 ## Slots syntax usage
 
@@ -101,7 +101,7 @@ In above example, the component interpolation follows the **list formatting**.  
 :new: 8.14+
 :::
 
-You use slots syntax with Named formatting then, It's more convenient. For example:
+It's more convenient to use the named slots syntax. For example:
 
 ```html
 <div id="app">
@@ -151,7 +151,7 @@ Outputs:
 </div>
 ```
 
-In Vue 2.6 and later,you can can use the following slots syntax in templates:
+In Vue 2.6 and later, you can can use the following slots syntax in templates:
 
 ```html
 <div id="app">
@@ -165,14 +165,14 @@ In Vue 2.6 and later,you can can use the following slots syntax in templates:
 ```
 
 :::warning Limitation
-:warning: In `i18n` component, slots porps is not supported.
+:warning: In `i18n` component, slots props are not supported.
 :::
 
 
 ## Places syntax usage
 
 :::danger Important!!
-In next major version, `place` attribute, `places` prop is deprecated. Please switch to slots syntax.
+In the next major version, the `place` and `places` props will be deprecated. Please switch to slots syntax.
 :::
 
 :::tip Support Version
@@ -180,7 +180,7 @@ In next major version, `place` attribute, `places` prop is deprecated. Please sw
 :::
 
 :::warning Notice
-:warning: In `i18n` component, text content consists of only white spaces will be omitted.
+:warning: In `i18n` component, text content consisting of only white spaces will be omitted.
 :::
 
 Named formatting is supported with the help of `place` attribute. For example:

--- a/vuepress/guide/lazy-loading.md
+++ b/vuepress/guide/lazy-loading.md
@@ -4,7 +4,7 @@ Loading all of your translation files at once is overkill and unnecessary.
 
 Lazy loading or asynchronously loading the translation files is really easy when using Webpack.
 
-Lets assume we have a project directory similar to the one bellow
+Let´s assume we have a project directory similar to the one below:
 
 ```
 our-cool-project
@@ -19,7 +19,7 @@ our-cool-project
 ---it.js
 ```
 
-The `lang` folder is where all of our translation files will reside. The `setup` folder is where our arbitrary setup files like the i18n-setup, global component inits, plugin inits and other reside.
+The `lang` folder is where all of our translation files reside. The `setup` folder is where our arbitrary setup files like the i18n-setup, global component inits, plugin inits and other reside.
 
 ```js
 //i18n-setup.js
@@ -36,7 +36,7 @@ export const i18n = new VueI18n({
   messages // set locale messages
 })
 
-const loadedLanguages = ['en'] // our default language that is preloaded 
+const loadedLanguages = ['en'] // our default language that is preloaded
 
 function setI18nLanguage (lang) {
   i18n.locale = lang
@@ -73,7 +73,7 @@ The `loadLanguageAsync` function is what we will actually use to change the lang
 
 You can learn more about the import function in the [Webpack documentation](https://webpack.js.org/guides/code-splitting/#dynamic-imports).
 
-Using the `loadLanguageAsync` function is straight forward. A common use case is inside a vue-router beforeEach hook.
+Using the `loadLanguageAsync` function is straightforward. A common use case is inside a vue-router beforeEach hook.
 
 ```js
 router.beforeEach((to, from, next) => {

--- a/vuepress/guide/messages.md
+++ b/vuepress/guide/messages.md
@@ -2,7 +2,7 @@
 
 ## Structure
 
-Locale Messages syntax the below:
+Locale Messages syntax below:
 
 ```typescript
 // As Flowtype definition, Locale Messages syntax like BNF annotation
@@ -14,7 +14,7 @@ type Locale = string;
 type Path = string;
 ```
 
-Based on the above syntax, You can configure the following structure Locale Messages:
+Based on the above syntax, You can configure the following Locale Messages structure:
 
 ```json
 {
@@ -39,7 +39,7 @@ Based on the above syntax, You can configure the following structure Locale Mess
 }
 ```
 
-In the above Locale Messages structure, You can translate with using below key paths.
+In the above Locale Messages structure, You can translate using below key paths.
 
 ```html
 <div id="app">
@@ -91,13 +91,13 @@ const messages = {
 }
 ```
 
-Template the below:
+Template:
 
 ```html
 <p>{{ $t('message.linked') }}</p>
 ```
 
-Output the below:
+Output:
 
 ```html
 <p>DIO: the world !!!!</p>
@@ -108,9 +108,9 @@ Output the below:
 
 A translation key of linked locale message can also have the form of `@:(message.foo.bar.baz)` in which the link to another translation key is within brackets `()`.
 
-This can be useful if the link `@:message.something` is following by period `.`, which can be a part of link but in case it should not be.
+This can be useful if the link `@:message.something` is followed by period `.`, which otherwise would be part of the link and may not need to be.
 
-Locale messages the below:
+Locale messages:
 
 ```js
 const messages = {
@@ -123,13 +123,13 @@ const messages = {
 }
 ```
 
-Template the below:
+Template:
 
 ```html
 <p>{{ $t('message.linked') }}</p>
 ```
 
-Output the below:
+Output:
 
 ```html
 <p>There's a reason, you lost, DIO.</p>

--- a/vuepress/guide/number.md
+++ b/vuepress/guide/number.md
@@ -23,9 +23,9 @@ const numberFormats = {
 }
 ```
 
-As the above, you can define the number format with name (e.g. `currency`, etc), and you need to use [the options with ECMA-402 Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
+As the above, you can define named number formats (e.g. `currency`, etc), and you need to use [the options with ECMA-402 Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
 
-After that like the locale messages, you need to specify the `numberFormats` option of `VueI18n` constructor:
+After that, when using the locale messages, you need to specify the `numberFormats` option of the `VueI18n` constructor:
 
 ```js
 const i18n = new VueI18n({
@@ -76,7 +76,7 @@ The following template:
 </div>
 ```
 
-will produce output below:
+will produce the below output:
 
 ```html
 <div id="app">
@@ -86,9 +86,9 @@ will produce output below:
 </div>
 ```
 
-But real power of this component comes into play when it is used with [scoped slots](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots).
+But the real power of this component comes into play when it is used with [scoped slots](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots).
 
-Lets say there is requirement to render integer part of the number with a bolder font. This can be achieved by specifying `integer` scoped slot element:
+Let's say there is a requirement to render the integer part of the number with a bolder font. This can be achieved by specifying `integer` scoped slot element:
 
 ```html
 <i18n-n :value="100" format="currency">

--- a/vuepress/guide/pluralization.md
+++ b/vuepress/guide/pluralization.md
@@ -15,7 +15,7 @@ const messages = {
 }
 ```
 
-Template the below:
+Template below:
 
 ```html
 <p>{{ $tc('car', 1) }}</p>
@@ -26,7 +26,7 @@ Template the below:
 <p>{{ $tc('apple', 10, { count: 10 }) }}</p>
 ```
 
-Output the below:
+Output below:
 
 ```html
 <p>car</p>
@@ -54,7 +54,7 @@ const messages = {
 }
 ```
 
-Template the below:
+Template below:
 
 ```html
 <p>{{ $tc('apple', 10, { count: 10 }) }}</p>
@@ -65,7 +65,7 @@ Template the below:
 <p>{{ $tc('banana', 100, { n: 'too much' }) }}</p>
 ```
 
-Output the below:
+Output below:
 
 ```html
 <p>10 apples</p>

--- a/vuepress/guide/sfc.md
+++ b/vuepress/guide/sfc.md
@@ -2,7 +2,7 @@
 
 ## Basic Usage
 
-If you are building Vue component or Vue application with using single file components, you can manage the locale messages `i18n` custom block.
+If you are building Vue component or Vue application using single file components, you can manage the locale messages `i18n` custom block.
 
 The following in [single file components example](https://github.com/kazupon/vue-i18n/tree/dev/examples/sfc):
 
@@ -34,7 +34,7 @@ export default {
   name: 'app',
   data () {
     this.$i18n.locale = 'en';
-    return { locale: 'en' } 
+    return { locale: 'en' }
   },
   watch: {
     locale (val) {
@@ -106,7 +106,7 @@ module.exports = {
 
 [Vue CLI 3.0](https://github.com/vuejs/vue-cli) hides the webpack configuration, so, if we want to add support to the `<i18n>` tag inside a single file component we need to modify the existing configuration.
 
-In order to do that we have to create a `vue.config.js` at the root of our project. Once done that, we have to include the following:
+In order to do that we have to create a `vue.config.js` at the root of our project. Once we have done that, we have to include the following:
 
 for vue-loader v15 or later:
 ```js
@@ -258,7 +258,7 @@ module.exports = {
 
 ## Multiple custom blocks
 
-You can be used the locale messages with multiple `i18n` custom block.
+You can use locale messages with multiple `i18n` custom blocks.
 
 ```html
 <i18n src="./common/locales.json"></i18n>
@@ -274,7 +274,7 @@ You can be used the locale messages with multiple `i18n` custom block.
 </i18n>
 ```
 
-In the above, first custom block load the common locale message with `src` attribute, second custom block load the locale message that defined only at single file component. These locale messages will be merged as locale message of component.
+In the above, first custom block load the common locale message with `src` attribute, second custom block load the locale message that is defined only at single file component. These locale messages will be merged as locale message of component.
 
 In this way, multiple custom blocks useful when want to be used as module.
 


### PR DESCRIPTION
As I was going through the English guide, I found and fixed a few very minor mistakes and/or sentences that are a bit clumsy.