### PR TITLE
dateTimeFormats lowercase lang key

### DIFF
--- a/vuepress/guide/datetime.md
+++ b/vuepress/guide/datetime.md
@@ -10,7 +10,7 @@ DateTime formats the below:
 
 ```js
 const dateTimeFormats = {
-  'en-US': {
+  'en-us': {
     short: {
       year: 'numeric', month: 'short', day: 'numeric'
     },
@@ -19,7 +19,7 @@ const dateTimeFormats = {
       weekday: 'short', hour: 'numeric', minute: 'numeric'
     }
   },
-  'ja-JP': {
+  'ja-jp': {
     short: {
       year: 'numeric', month: 'short', day: 'numeric'
     },


### PR DESCRIPTION
We got this warning and formats are not loaded if keys are not lowercased
```
"Fall back to 'en-us' datetime formats from 'en-us' datetime formats."
```

