### PR TITLE
Fix error with locale message example

### DIFF
--- a/vuepress/guide/messages.md
+++ b/vuepress/guide/messages.md
@@ -127,7 +127,7 @@ const messages = {
 ```
 
 ```html
-<label>{{ $t('message.missingHomeAddress') }}</label>
+<label>{{ $t('message.homeAddress') }}</label>
 
 <p class="error">{{ $t('message.missingHomeAddress') }}</p>
 ```


### PR DESCRIPTION
On line 130 it should be `message.homeAddress` and not `message.missingHomeAddress`.

Example: https://kazupon.github.io/vue-i18n/guide/messages.html#linked-locale-messages

