### PR TITLE
Fix example for "one" plural category in Russian

### DIFF
--- a/vuepress/guide/pluralization.md
+++ b/vuepress/guide/pluralization.md
@@ -121,8 +121,8 @@ This would effectively give this:
 ```javascript
 const messages = {
   ru: {
-    car: '0 машин | 1 машина | {n} машины | {n} машин',
-    banana: 'нет бананов | 1 банан | {n} банана | {n} бананов'
+    car: '0 машин | {n} машина | {n} машины | {n} машин',
+    banana: 'нет бананов | {n} банан | {n} банана | {n} бананов'
   }
 }
 ```


### PR DESCRIPTION
You won't get "21 машина" or "31 банан" since 1 was hardcoded into text

