### PR TITLE
Put dash at the end of character class in example i18n.js code.

### DIFF
--- a/examples/hot/src/i18n.js
+++ b/examples/hot/src/i18n.js
@@ -4,10 +4,10 @@ import VueI18n from 'vue-i18n'
 Vue.use(VueI18n)
 
 function loadLocaleInfo () {
-  const locales = require.context('./locales', true, /[A-Za-z0-9-_,\s]+\.json$/i)
+  const locales = require.context('./locales', true, /[A-Za-z0-9_,\s-]+\.json$/i)
   const messages = {}
   locales.keys().forEach(key => {
-    const matched = key.match(/([A-Za-z0-9-_]+)\./i)
+    const matched = key.match(/([A-Za-z0-9_-]+)\./i)
     if (matched && matched.length > 1) {
       const locale = matched[1]
       messages[locale] = locales(key)

--- a/examples/hot/src/i18n.js
+++ b/examples/hot/src/i18n.js
@@ -4,7 +4,7 @@ import VueI18n from 'vue-i18n'
 Vue.use(VueI18n)
 
 function loadLocaleInfo () {
-  const locales = require.context('./locales', true, /[A-Za-z0-9_,\s-]+\.json$/i)
+  const locales = require.context('./locales', true, /(^|\/)[A-Za-z0-9_,\s-]+\.json$/i)
   const messages = {}
   locales.keys().forEach(key => {
     const matched = key.match(/([A-Za-z0-9_-]+)\./i)


### PR DESCRIPTION
The regexp /[0-9-_]/ matches digits, hyphen, and underscore, but only
because the hyphen comes right after a hyphenated range.  If you put
anything in between the 9 and the hyphen, boom.  It's so surprising, I
think it's clearer just to put the hyphen at the end.

