### PR TITLE
Fixed bug when changing number format runtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -717,10 +717,24 @@ export default class VueI18n {
 
   setNumberFormat (locale: Locale, format: NumberFormat): void {
     this._vm.$set(this._vm.numberFormats, locale, format)
+    this._clearNumberFormat(locale, format)
   }
 
   mergeNumberFormat (locale: Locale, format: NumberFormat): void {
     this._vm.$set(this._vm.numberFormats, locale, merge(this._vm.numberFormats[locale] || {}, format))
+    this._clearNumberFormat(locale, format)
+  }
+
+  _clearNumberFormat (locale: Locale, format: NumberFormat): void {
+    for (const key in format) {
+      const id = `${locale}__${key}`
+
+      if (!this._numberFormatters.hasOwnProperty(id)) {
+        continue
+      }
+
+      delete this._numberFormatters[id]
+    }
   }
 
   _getNumberFormatter (

--- a/test/unit/number_component.test.js
+++ b/test/unit/number_component.test.js
@@ -260,6 +260,39 @@ desc('number custom formatting', () => {
     })
   })
 
+  describe('change number format runtime', () => {
+    it('should be changed', done => {
+      const i18n = new VueI18n({
+        locale: 'en-US',
+        numberFormats
+      })
+      const el = document.createElement('div')
+      document.body.appendChild(el)
+
+      const money = 101
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('p', { ref: 'text' }, [this.$n(money, 'currency')])
+        }
+      }).$mount(el)
+
+      const { text } = vm.$refs
+      const otherEnFormat = {
+        currency: {
+          style: 'currency', currency: 'CZK', currencyDisplay: 'name'
+        }
+      }
+
+      nextTick(() => {
+        assert.strictEqual(text.textContent, '$101.00')
+        i18n.setNumberFormat('en-US', otherEnFormat)
+      }).then(() => {
+        assert.strictEqual(text.textContent, '101.00 Czech korunas')
+      }).then(done)
+    })
+  })
+
   describe('warnning in render', () => {
     it('should be warned', () => {
       const spy = sinon.spy(console, 'warn')


### PR DESCRIPTION
Hello, just prepared PR that fixes #815.
If new number format is set/merge this new code purges the old formatter if exists.
So now you are able to change number format runtime. 
Before when the formatter was instanciated it was not possible to change the number format. 