### PR TITLE
fix in examples of "Custom pluralization"

### DIFF
--- a/vuepress/guide/pluralization.md
+++ b/vuepress/guide/pluralization.md
@@ -85,6 +85,9 @@ In order to implement these rules you can override the `VueI18n.prototype.getCho
 
 Very simplified example using rules for Slavic languages (Russian, Ukrainian, etc.):
 ```js
+
+const defaultImpl = VueI18n.prototype.getChoiceIndex
+
 /**
  * @param choice {number} a choice index given by the input to $tc: `$tc('path.to.rule', choiceIndex)`
  * @param choicesLength {number} an overall amount of available choices
@@ -94,6 +97,7 @@ VueI18n.prototype.getChoiceIndex = function (choice, choicesLength) {
   // this === VueI18n instance, so the locale property also exists here
   if (this.locale !== 'ru') {
     // proceed to the default implementation
+    return defaultImpl.apply(this, arguments)
   }
 
   if (choice === 0) {

--- a/vuepress/zh/guide/pluralization.md
+++ b/vuepress/zh/guide/pluralization.md
@@ -81,6 +81,9 @@ const messages = {
 
 使用斯拉夫语言规则的简化示例 (俄语、乌克兰语等)：
 ```js
+
+const defaultImpl = VueI18n.prototype.getChoiceIndex
+
 /**
  * @param choice {number} 由 $tc 输入的选择索引：`$tc('path.to.rule', choiceIndex)`
  * @param choicesLength {number} 总体可用选择
@@ -90,6 +93,7 @@ VueI18n.prototype.getChoiceIndex = function (choice, choicesLength) {
   // this === VueI18n 实例，所以语言环境属性也存在于此处
   if (this.locale !== 'ru') {
     // 继续执行默认实现
+    return defaultImpl.apply(this, arguments)
   }
 
   if (choice === 0) {


### PR DESCRIPTION
Hello!

You example in **"Custom pluralization"** section doesn't consist **"proceed to the default implementation"** code

I think this will fix it.