### PR TITLE
Ensure IE11 compatibility using eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
   },
-  plugins: ['flowtype', 'ie11'],
+  plugins: ['flowtype', 'ie11', 'no-autofix'],
   extends: [
     'plugin:vue-libs/recommended',
     'plugin:flowtype/recommended'
@@ -13,6 +13,8 @@ module.exports = {
     'ie11/no-for-in-const': [ 'error' ],
     'ie11/no-loop-func': [ 'warn' ],
     'ie11/no-weak-collections': [ 'error' ],
+    'prefer-const': 'off',
+    'no-autofix/prefer-const': 'warn',
     'object-curly-spacing': ['error', 'always'],
     'no-multiple-empty-lines': ['error', { max: 2, maxBOF: 1 }]
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,12 +3,16 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
   },
-  plugins: ['flowtype'],
+  plugins: ['flowtype', 'ie11'],
   extends: [
     'plugin:vue-libs/recommended',
     'plugin:flowtype/recommended'
   ],
   rules: {
+    'ie11/no-collection-args': [ 'error' ],
+    'ie11/no-for-in-const': [ 'error' ],
+    'ie11/no-loop-func': [ 'warn' ],
+    'ie11/no-weak-collections': [ 'error' ],
     'object-curly-spacing': ['error', 'always'],
     'no-multiple-empty-lines': ['error', { max: 2, maxBOF: 1 }]
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^5.6.0",
     "eslint-loader": "^2.1.0",
     "eslint-plugin-flowtype": "^2.47.0",
+    "eslint-plugin-ie11": "^1.0.0",
     "eslint-plugin-vue-libs": "^2.0.1",
     "flow-bin": "^0.38.0",
     "http-server": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-loader": "^2.1.0",
     "eslint-plugin-flowtype": "^2.47.0",
     "eslint-plugin-ie11": "^1.0.0",
+    "eslint-plugin-no-autofix": "^1.0.1",
     "eslint-plugin-vue-libs": "^2.0.1",
     "flow-bin": "^0.38.0",
     "http-server": "^0.11.1",

--- a/src/index.js
+++ b/src/index.js
@@ -385,7 +385,7 @@ export default class VueI18n {
     // We are going to replace each of
     // them with its translation
     const matches: any = ret.match(linkKeyMatcher)
-    for (const idx in matches) {
+    for (let idx in matches) {
       // ie compatible: filter custom array
       // prototype method
       if (!matches.hasOwnProperty(idx)) {
@@ -834,7 +834,7 @@ export default class VueI18n {
   }
 
   _clearNumberFormat (locale: Locale, format: NumberFormat): void {
-    for (const key in format) {
+    for (let key in format) {
       const id = `${locale}__${key}`
 
       if (!this._numberFormatters.hasOwnProperty(id)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,6 +5133,13 @@ eslint-plugin-html@^4.0.1:
   dependencies:
     htmlparser2 "^3.8.2"
 
+eslint-plugin-ie11@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz#8990e5d9a7212cc12f621e89c86a32d6d37fdfc5"
+  integrity sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-vue-libs@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue-libs/-/eslint-plugin-vue-libs-2.1.0.tgz#e7faf4ae11dad58553f63f907d6642e2d816dcef"
@@ -11002,6 +11009,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requires-port@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5140,12 +5140,24 @@ eslint-plugin-ie11@^1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
+eslint-plugin-no-autofix@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-autofix/-/eslint-plugin-no-autofix-1.0.1.tgz#e2ef47ec92346519c081322360ed201bbe62b223"
+  integrity sha512-ZwQF1S+tsl9alr8DuoHX9KcNI+BxCK+D08I1n6NXlitIJg3AB+1EtHYMoxz0LFKKsewoUYo2M4QcHZxGqV1T7w==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-plugin-vue-libs@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue-libs/-/eslint-plugin-vue-libs-2.1.0.tgz#e7faf4ae11dad58553f63f907d6642e2d816dcef"
   integrity sha512-FFiJJ3apqnXkb3+mIgr4juPKWXL/Bo4jORbW8qYpY78+iRzOLBDcOJGyD6z52h2kO5EqMRfzrfo4Q/28CUPuJw==
   dependencies:
     eslint-plugin-html "^4.0.1"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@3.7.1:
   version "3.7.1"


### PR DESCRIPTION
Addresses #842

* `eslint-plugin-ie11` is added to check IE11 compatiblity on `lint`.
* Also `eslint-plugin-no-autofix` is added to suppress auto-fix on `prefer-const` rule, which conflict with `ie11/no-for-in-const` rule.
    * `prefer-const`  enforces `const` where possible.
    * but `ie11/no-for-in-const` enforces `let/var` in for-in loop.

