### PR TITLE
add key to postTranslation

### DIFF
--- a/decls/i18n.js
+++ b/decls/i18n.js
@@ -51,7 +51,7 @@ declare type TranslateResult = string | LocaleMessages;
 declare type DateTimeFormatResult = string;
 declare type NumberFormatResult = string;
 declare type MissingHandler = (locale: Locale, key: Path, vm?: any) => string | void;
-declare type PostTranslationHandler = (str: string) => string;
+declare type PostTranslationHandler = (str: string, key?: string) => string;
 
 declare type FormattedNumberPartType = 'currency' | 'decimal' | 'fraction' | 'group' | 'infinity' | 'integer' | 'literal' | 'minusSign' | 'nan' | 'plusSign' | 'percentSign';
 declare type FormattedNumberPart = {

--- a/src/index.js
+++ b/src/index.js
@@ -599,7 +599,7 @@ export default class VueI18n {
     } else {
       ret = this._warnDefault(locale, key, ret, host, values, 'string')
       if (this._postTranslation && ret !== null && ret !== undefined) {
-        ret = this._postTranslation(ret)
+        ret = this._postTranslation(ret, key)
       }
       return ret
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,7 @@ declare namespace VueI18n {
   }
 
   type MissingHandler = (locale: Locale, key: Path, vm: Vue | null, values: any) => string | void;
-  type PostTranslationHandler = (str: string) => string;
+  type PostTranslationHandler = (str: string, key?: string) => string;
 
   interface IntlAvailability {
     dateTimeFormat: boolean;


### PR DESCRIPTION
I think it will be great to add possibility, for example, to trim translated string filtered by a key.
So, this PR adds a `key` argument to handler postTranslation