### PR TITLE
Don't delete _i18n in beforeDestroy

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -127,8 +127,6 @@ export default {
         self._localeWatcher()
         delete self._localeWatcher
       }
-
-      self._i18n = null
     })
   }
 }

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -135,8 +135,6 @@ describe('component translation', () => {
       assert.strictEqual(subChild2.textContent, 'sub-child2')
 
       vm.$destroy()
-    }).then(() => {
-      assert(vm.$i18n === null)
     }).then(done)
   })
 })

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -693,4 +693,22 @@ describe('issues', () => {
       assert.strictEqual(vm.$te('message.empty'), true)
     })
   })
+
+  describe('#879', () => {
+    it('$t should not throw when invoked on a destroyed component', async () => {
+      const vm = new Vue({
+        i18n: new VueI18n({ locale: 'en' }),
+        methods: {
+          test: async function () {
+            // Long running async method that terminates after the component is destroyed.
+            await new Promise((resolve) => setTimeout(resolve, 50))
+            this.$t('anything')
+          }
+        }
+      })
+      const promise = vm.test() // invocation before being destroyed
+      vm.$destroy()
+      await promise // should not throw
+    })
+  })
 })


### PR DESCRIPTION
Avoid that attempts to call methods on _i18n after destroying a
component fail. This is for example relevant for long running
async methods that were called before the component got destroyed
but terminate after the destruction and then try to call an i18n
method.
Note that _18n doesn't need to be cleared manually. It gets
garbage collected when the destroyed component gets destroyed.

Fixes #879

Other than mentioned in the issue, no addition of a boolean flag was
necessary, as the `beforeDestroy` hook is not called more than once and
the cleanup is only necessary if `_i18n` exists. Therefore the check for
`_i18n` still suffices.