### PR TITLE
fix v-t pluralisation when choice is 0

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -73,7 +73,7 @@ function t (el: any, binding: Object, vnode: any): void {
   }
 
   const vm: any = vnode.context
-  if (choice) {
+  if (choice != null) {
     el._vt = el.textContent = vm.$i18n.tc(path, choice, ...makeParams(locale, args))
   } else {
     el._vt = el.textContent = vm.$i18n.t(path, ...makeParams(locale, args))

--- a/test/unit/directive.test.js
+++ b/test/unit/directive.test.js
@@ -198,6 +198,26 @@ describe('custom directive', () => {
           assert.strictEqual(vm.$refs.text._vt, 'cars')
         }).then(done)
       })
+
+      it('should allow a zero choice', done => {
+        const vm = createVM({
+          i18n,
+          render (h) {
+            // <p ref="text" v-t="{path: 'plurals.apple', choice: 0}"></p>
+            return h('p', { ref: 'text', directives: [{
+              name: 't', rawName: 'v-t', value: ({ path: 'plurals.apple', choice: 0 }), expression: { path: 'plurals.apple', choice: 0 }
+            }] })
+          }
+        })
+        nextTick(() => {
+          assert.strictEqual(vm.$refs.text.textContent, 'no apples')
+          assert.strictEqual(vm.$refs.text._vt, 'no apples')
+          vm.$forceUpdate()
+        }).then(() => {
+          assert.strictEqual(vm.$refs.text.textContent, 'no apples')
+          assert.strictEqual(vm.$refs.text._vt, 'no apples')
+        }).then(done)
+      })
     })
 
     describe('preserve content', () => {


### PR DESCRIPTION
the directive was displaying the entire string instead of the correct pluralisation