### PR TITLE
Fix flow types and enable flow types testing on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,10 @@ jobs:
       - run:
           name: Lint
           command: yarn lint
-      #- run: yarn flow
+      - run:
+          name: Flow Types
+          # https://discuss.circleci.com/t/circleci-terminal-is-a-tty-but-term-is-not-set/9965/8
+          command: TERM=dumb yarn flow
       - run:
           name: TS Types
           command: yarn test:types

--- a/decls/i18n.js
+++ b/decls/i18n.js
@@ -52,6 +52,7 @@ declare type DateTimeFormatResult = string;
 declare type NumberFormatResult = string;
 declare type MissingHandler = (locale: Locale, key: Path, vm?: any) => string | void;
 declare type PostTranslationHandler = (str: string, key?: string) => string;
+declare type GetChoiceIndex = (choice: number, choicesLength: number) => number
 declare type ComponentInstanceCreatedListener = (newI18n: I18n, rootI18n: I18n) => void;
 
 declare type FormattedNumberPartType = 'currency' | 'decimal' | 'fraction' | 'group' | 'infinity' | 'integer' | 'literal' | 'minusSign' | 'nan' | 'plusSign' | 'percentSign';
@@ -144,7 +145,7 @@ declare interface I18n {
   setNumberFormat (locale: Locale, format: NumberFormat): void,
   mergeNumberFormat (locale: Locale, format: NumberFormat): void,
   n (value: number, ...args: any): NumberFormatResult,
-  getChoiceIndex: (choice: number, choicesLength: number) => number,
+  getChoiceIndex: GetChoiceIndex,
   pluralizationRules: PluralizationRules,
   preserveDirectiveContent: boolean
 };

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -569,7 +569,7 @@ describe('issues', () => {
         locale: 'ru',
         messages: {
           ru: {
-            car: '0 машин | 1 машина | {n} машины | {n} машин'
+            car: '0 машин | {n} машина | {n} машины | {n} машин'
           }
         },
         pluralizationRules: {
@@ -578,12 +578,12 @@ describe('issues', () => {
       })
       vm = new Vue({ i18n })
 
-      assert(vm.$tc('car', 0), '0 машин')
-      assert(vm.$tc('car', 1), '1 машина')
-      assert(vm.$tc('car', 2), '2 машины')
-      assert(vm.$tc('car', 4), '4 машины')
-      assert(vm.$tc('car', 12), '12 машин')
-      assert(vm.$tc('car', 21), '21 машина')
+      assert.strictEqual(vm.$tc('car', 0), '0 машин')
+      assert.strictEqual(vm.$tc('car', 1), '1 машина')
+      assert.strictEqual(vm.$tc('car', 2), '2 машины')
+      assert.strictEqual(vm.$tc('car', 4), '4 машины')
+      assert.strictEqual(vm.$tc('car', 12), '12 машин')
+      assert.strictEqual(vm.$tc('car', 21), '21 машина')
     })
 
     it('ensures backward-compatibility with #451', () => {
@@ -617,21 +617,21 @@ describe('issues', () => {
 
 
       i18n = new VueI18n({
-        locale: 'en',
+        locale: 'ru',
         messages: {
           ru: {
-            car: '0 машин | 1 машина | {n} машины | {n} машин'
+            car: '0 машин | {n} машина | {n} машины | {n} машин'
           }
         }
       })
       vm = new Vue({ i18n })
 
-      assert(vm.$tc('car', 0), '0 машин')
-      assert(vm.$tc('car', 1), '1 машина')
-      assert(vm.$tc('car', 2), '2 машины')
-      assert(vm.$tc('car', 4), '4 машины')
-      assert(vm.$tc('car', 12), '12 машин')
-      assert(vm.$tc('car', 21), '21 машина')
+      assert.strictEqual(vm.$tc('car', 0), '0 машин')
+      assert.strictEqual(vm.$tc('car', 1), '1 машина')
+      assert.strictEqual(vm.$tc('car', 2), '2 машины')
+      assert.strictEqual(vm.$tc('car', 4), '4 машины')
+      assert.strictEqual(vm.$tc('car', 12), '12 машин')
+      assert.strictEqual(vm.$tc('car', 21), '21 машина')
 
       // Set the default implementation back
       VueI18n.prototype.getChoiceIndex = defaultImpl
@@ -662,14 +662,14 @@ describe('issues', () => {
         },
         formatter: {
           interpolate (message, values, path) {
-            assert(path, testPath)
+            assert.strictEqual(path, testPath)
 
             return null // pass the case to the default formatter
           }
         }
       })
 
-      assert(i18n.t(testPath), 'Hello!')
+      assert.strictEqual(i18n.t(testPath), 'Hello!')
     })
   })
 


### PR DESCRIPTION
The change related to `getChoiceIndex` is IMO a correct fix. It's necessary as just declaring `getChoiceIndex` as a method of the class makes it `read-only` and that is not compatible with flow types that have `getChoiceIndex` as a property (correctly as this method is overridable through `VueI18n.prototype`).

Also enables unit tests and flow types testing on CI