### PR TITLE
Make link to API and Guide top level

### DIFF
--- a/vuepress/.vuepress/config.js
+++ b/vuepress/.vuepress/config.js
@@ -33,17 +33,12 @@ module.exports = {
         lastUpdated: 'Last Updated',
         nav: [
           {
-            text: 'Learn',
-            items: [
-              {
-                text: 'Guide',
-                link: '/guide/formatting',
-              },
-              {
-                text: 'API',
-                link: '/api/'
-              }
-            ]
+            text: 'Guide',
+            link: '/guide/formatting'
+          },
+          {
+            text: 'API',
+            link: '/api/'
           },
           {
             text: 'Ecosystem',
@@ -134,17 +129,12 @@ module.exports = {
         lastUpdated: '最近一次更新',
         nav: [
           {
-            text: '学习',
-            items: [
-              {
-                text: '指南',
-                link: '/zh/guide/formatting',
-              },
-              {
-                text: 'API',
-                link: '/zh/api/'
-              }
-            ]
+            text: '指南',
+            link: '/zh/guide/formatting',
+          },
+          {
+            text: 'API',
+            link: '/zh/api/'
           },
           {
             text: '生态',
@@ -231,17 +221,12 @@ module.exports = {
         lastUpdated: 'Последнее обновление',
         nav: [
           {
-            text: 'Документация',
-            items: [
-              {
-                text: 'Руководство',
-                link: '/ru/guide/formatting',
-              },
-              {
-                text: 'Справочник API',
-                link: '/ru/api/'
-              }
-            ]
+            text: 'Руководство',
+            link: '/ru/guide/formatting',
+          },
+          {
+            text: 'Справочник API',
+            link: '/ru/api/'
           },
           {
             text: 'Экосистема',


### PR DESCRIPTION
We don't have many options in Learn section, and API reference hidden beside select is hard to discover.
Similar solutions are made in vuex, vue router and so on.

#915

Previous version: 
![image](https://user-images.githubusercontent.com/15820496/84359045-b49da900-abd0-11ea-8c36-f86b38742301.png)


Proposed version:
![image](https://user-images.githubusercontent.com/15820496/84359085-c67f4c00-abd0-11ea-9313-9600599608e7.png)


