### PR TITLE
:zap: improvement(interpolation): enable passage of local components to tag prop

### DIFF
--- a/src/components/interpolation.js
+++ b/src/components/interpolation.js
@@ -7,7 +7,7 @@ export default {
   functional: true,
   props: {
     tag: {
-      type: [String, Boolean],
+      type: [String, Boolean, Object],
       default: 'span'
     },
     path: {

--- a/test/unit/interpolation.test.js
+++ b/test/unit/interpolation.test.js
@@ -61,6 +61,43 @@ describe('component interpolation', () => {
       }).then(done)
     })
 
+    it('of type object (Component) should be correctly applied', done => {
+      const MockElement = {
+        render(h) {
+          return h('strong', Object.values(this.$slots));
+        },
+      }
+      const el = document.createElement('div')
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n', { props: { path: 'text', tag: MockElement } }, [this._v('1')])
+        }
+      }).$mount(el)
+      Vue.nextTick().then(() => {
+        assert.strictEqual(vm.$el.outerHTML, '<strong>one: 1</strong>')
+      }).then(done).catch(done)
+    })
+
+    it('of type object (Functional Component) should be correctly applied', done => {
+      const MockElement = {
+        functional: true,
+        render(h, { data, children }) {
+          return h('em', data, children);
+        },
+      }
+      const el = document.createElement('div')
+      const vm = new Vue({
+        i18n,
+        render (h) {
+          return h('i18n', { props: { path: 'text', tag: MockElement } }, [this._v('1')])
+        }
+      }).$mount(el)
+      Vue.nextTick().then(() => {
+        assert.strictEqual(vm.$el.outerHTML, '<em>one: 1</em>')
+      }).then(done).catch(done)
+    })
+
     it('of type string should be correctly applied', done => {
       const el = document.createElement('div')
       const vm = new Vue({


### PR DESCRIPTION
This should enable the user to, not only pass global components and html tags, but also locally imported components.

***

Of note: I commited this changes directly on github web interface. So I didn't write tests or any lint on commit, I did so because I want to just test the ideia with the community/mantainers, if you like the idea I'm more than willing to fix any mistakes I may have commited.

