### PR TITLE
Update mixin.js

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -47,7 +47,7 @@ export default {
         // init locale messages via custom blocks
         if (options.__i18n) {
           try {
-            let localeMessages = {}
+            let localeMessages = options.i18n && options.i18n.messages ? options.i18n.messages : {}
             options.__i18n.forEach(resource => {
               localeMessages = merge(localeMessages, JSON.parse(resource))
             })

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -13,7 +13,7 @@ export default {
         // init locale messages via custom blocks
         if (options.__i18n) {
           try {
-            let localeMessages = {}
+            let localeMessages = options.i18n && options.i18n.messages ? options.i18n.messages : {}
             options.__i18n.forEach(resource => {
               localeMessages = merge(localeMessages, JSON.parse(resource))
             })

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -738,6 +738,23 @@ describe('issues', () => {
 
       assert(componentInstanceCreatedListener.called === false)
     })
+    
+  describe('#996', () => {
+    it('should merge __i18n and i18n', done => {
+      const component = Vue.extend({
+        __i18n: [JSON.stringify({en: { custom: 'custom block!' }})],
+        i18n: {messages: {en: {another: 'another block!'}}}
+        render (h) {
+          return h('p')
+        }
+      })
+      const vm = new Component({ i18n }).$mount()
+      Vue.nextTick().then(() => {
+        assert.strictEqual(vm.$t('custom'), 'custom block!')
+        assert.strictEqual(vm.$t('another'), 'another block!')
+      }).then(done)
+    })
+  })
 
     it('should call "componentInstanceCreatedListener" on creating local instance', () => {
       const componentInstanceCreatedListener = sinon.spy()

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -738,23 +738,6 @@ describe('issues', () => {
 
       assert(componentInstanceCreatedListener.called === false)
     })
-    
-  describe('#996', () => {
-    it('should merge __i18n and i18n', done => {
-      const component = Vue.extend({
-        __i18n: [JSON.stringify({en: { custom: 'custom block!' }})],
-        i18n: {messages: {en: {another: 'another block!'}}}
-        render (h) {
-          return h('p')
-        }
-      })
-      const vm = new Component({ i18n }).$mount()
-      Vue.nextTick().then(() => {
-        assert.strictEqual(vm.$t('custom'), 'custom block!')
-        assert.strictEqual(vm.$t('another'), 'another block!')
-      }).then(done)
-    })
-  })
 
     it('should call "componentInstanceCreatedListener" on creating local instance', () => {
       const componentInstanceCreatedListener = sinon.spy()
@@ -785,6 +768,26 @@ describe('issues', () => {
       console.info(componentInstanceCreatedListener.args)
       assert(componentInstanceCreatedListener.args[0][0] instanceof VueI18n) // new instance
       assert.strictEqual(componentInstanceCreatedListener.args[0][1], i18n)
+    })
+  })
+
+  describe('#996', () => {
+    it('should merge __i18n and i18n', done => {
+      const Component = Vue.extend({
+        __i18n: [JSON.stringify({ en: { custom: 'custom block!' } })],
+        render (h) {
+          return h('p')
+        }
+      })
+      const vm = new Component({
+        i18n: new VueI18n({ locale: 'en', messages: { en: { another: 'another block!' } } })
+      }).$mount()
+
+      Vue.nextTick().then(() => {
+        assert.strictEqual(vm.$t('another'), 'another block!')
+        assert.strictEqual(vm.$t('custom'), 'custom block!')
+      }).then(done)
+        .catch(console.error)
     })
   })
 })


### PR DESCRIPTION
This PR fixes a bug that happens when a SFC has a \<i18n\> block aswell as a i18n configuration in the Vue Component options.
Previously, the i18n configuration from the Vue Component options would be overridden by the \<i18n\> block; Using this new behaviour, the \<i18n\> block and the i18n configuration from the Vue Component options are merged.
This also helps to provide mixin support, since now a consumer of this library can have a SFC as a parent component, which uses a Vue mixin, and using a custom vue optionMergeStrategy, full mixin support can be achieved from consumer side.

