### PR TITLE
docs(tooling): adds vue-i18n-extract to the list of 3rd party tooling

### DIFF
--- a/vuepress/guide/tooling.md
+++ b/vuepress/guide/tooling.md
@@ -59,3 +59,14 @@ Read more about i18n Ally in [README](https://github.com/antfu/i18n-ally/blob/ma
 [i18nPlugin](https://github.com/nyavro/i18nPlugin) Intellij idea i18next support plugin ( [Jetbrains plugin page ](https://plugins.jetbrains.com/plugin/12981-i18n-support)).
 
 Plugin for i18n typescript/javascript/PHP. Supports vue-i18n. To enable vue-i18n support go to settings -> Tools -> i18n Plugin configuration and check "Vue-i18n". You need set vue locales directory (locales by default).
+
+### vue-i18n-extract
+
+[vue-i18n-extract](https://github.com/pixari/vue-i18n-extract) performs static analysis on a Vue.js project based on vue-i18n and reports the following information:
+
+- list of all the **unused vue-i18n keys** (entries found in the language files but not used in the project)
+- list of all the **missing keys** (entries fond in the project but not in the language files)
+
+It's possible to show the output in the console or to write it in a json file.
+
+The missing keys can be also automatically added to the given language files.


### PR DESCRIPTION
### Topic:
Adding a new tool (vue-i18n-extract) to the "tooling" page

**vue-i18n-extract** performs a static analysis on a Vue.js project based on **vue-i18n** and reports the following information:
-     list of all the unused vue-i18n keys (entries found in the language files but not used in the project)
-     list of all the missing keys (entries fond in the project but not in the language files)
Optionally you can decide to show the output in the console on in a json file.
The missing keys can be also automatically added to the given language files.

### Why
vue-i18n-extract is a specific tool for vue-i18n, it's older than 1 year and it's mature and stable.
According to the feedback and to the usage statistics it is a useful tool for people who are working with vue-i18n.
