### PR TITLE
Fix typo, espaceParameterHtml -> escapeParameterHtml in README. #1002

### DIFF
--- a/vuepress/api/README.md
+++ b/vuepress/api/README.md
@@ -373,7 +373,7 @@ A handler for getting notified when component-local instance was created. The ha
 
 This handler is useful when extending the root VueI18n instance and wanting to also apply those extensions to component-local instance.
 
-#### espaceParameterHtml
+#### escapeParameterHtml
 
 > 8.22+
 


### PR DESCRIPTION
Unfortunately there was a typo in the README segment I added that I didn't notice until after the release :/

This PR fixes it.