### PR TITLE
escapeParameterHtml flag: Don't escape ampersand #1019

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -174,7 +174,6 @@ export function looseEqual (a: any, b: any): boolean {
  */
 function escapeHtml(rawText: string): string {
   return rawText
-    .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')

--- a/test/unit/escape_parameter_html.test.js
+++ b/test/unit/escape_parameter_html.test.js
@@ -12,18 +12,19 @@ describe('escapeParameterHtml', () => {
       messages,
       escapeParameterHtml: true
     })
-    assert(i18n.t('nameformat', { key: '<&"\'>' }) === '&lt;&amp;&quot;&apos;&gt;')
-    assert(i18n.t('listformat', ['<&"\'>']) === '&lt;&amp;&quot;&apos;&gt;')
-    assert(i18n.tc('nameformat', 1, { key: '<&"\'>' }).toString() === '&lt;&amp;&quot;&apos;&gt;')
-    assert(i18n.tc('listformat', 1, ['<&"\'>']).toString() === '&lt;&amp;&quot;&apos;&gt;')
+    // We should not escape the ampersand (&).
+    assert(i18n.t('nameformat', { key: '<&"\'>' }) === '&lt;&&quot;&apos;&gt;')
+    assert(i18n.t('listformat', ['<&"\'>']) === '&lt;&&quot;&apos;&gt;')
+    assert(i18n.tc('nameformat', 1, { key: '<&"\'>' }).toString() === '&lt;&&quot;&apos;&gt;')
+    assert(i18n.tc('listformat', 1, ['<&"\'>']).toString() === '&lt;&&quot;&apos;&gt;')
   })
   it('Replacement parameters are not escaped when escapeParameterHtml: undefined.', () => {
     const i18n = new VueI18n({
       locale: 'en',
       messages,
     })
-    assert(i18n.t('nameformat', { key: '<&"\'>' }) === '<&"\'>')
-    assert(i18n.t('listformat', ['<&"\'>']) === '<&"\'>')
+    assert(i18n.t('nameformat', { key: '<"\'>' }) === '<"\'>')
+    assert(i18n.t('listformat', ['<"\'>']) === '<"\'>')
 
   })
 })

--- a/vuepress/api/README.md
+++ b/vuepress/api/README.md
@@ -385,7 +385,7 @@ If `escapeParameterHtml` is configured as true then interpolation parameters are
 This is useful when translation output is used in `v-html` and the translation resource contains html markup (e.g. `<b>`
 around a user provided value). This usage pattern mostly occurs when passing precomputed text strings into UI compontents.
 
-The escape process involves replacing the following symbols with their respective HTML character entities: `<`, `>`, `"`, `'`, `&`.
+The escape process involves replacing the following symbols with their respective HTML character entities: `<`, `>`, `"`, `'`.
 
 Setting `escapeParameterHtml` as true should not break existing functionality but provides a safeguard against a subtle
 type of XSS attack vectors.


### PR DESCRIPTION
This PR implements the changes proposed in issue #1019 - avoid escaping the ampersand symbol when the flag is raised.