### PR TITLE
@types: Fixed too narrow option types in n() and d() methods

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -184,7 +184,7 @@ export declare interface IVueI18n {
     locale?: VueI18n.Locale,
   ): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;
-  d(value: number, options?: VueI18n.DateTimeFormatOptions): VueI18n.DateTimeFormatResult;
+  d(value: number | Date, options?: VueI18n.DateTimeFormatOptions): VueI18n.DateTimeFormatResult;
   n(value: number, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.NumberFormatResult;
   n(value: number, args?: { [key: string]: string }): VueI18n.NumberFormatResult;
   n(value: number, options?: VueI18n.NumberFormatOptions): VueI18n.NumberFormatResult;
@@ -227,7 +227,7 @@ declare class VueI18n {
   te(key: VueI18n.Path, locale?: VueI18n.Locale): boolean;
   d(value: number | Date, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;
-  d(value: number, options?: VueI18n.DateTimeFormatOptions): VueI18n.DateTimeFormatResult;  
+  d(value: number | Date, options?: VueI18n.DateTimeFormatOptions): VueI18n.DateTimeFormatResult;  
   n(value: number, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.NumberFormatResult;
   n(value: number, args?: { [key: string]: string }): VueI18n.NumberFormatResult;
   n(value: number, options?: VueI18n.NumberFormatOptions): VueI18n.NumberFormatResult;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -184,8 +184,10 @@ export declare interface IVueI18n {
     locale?: VueI18n.Locale,
   ): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;
+  d(value: number, options?: VueI18n.DateTimeFormatOptions): VueI18n.DateTimeFormatResult;
   n(value: number, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.NumberFormatResult;
   n(value: number, args?: { [key: string]: string }): VueI18n.NumberFormatResult;
+  n(value: number, options?: VueI18n.NumberFormatOptions): VueI18n.NumberFormatResult;
   getLocaleMessage(locale: VueI18n.Locale): VueI18n.LocaleMessageObject;
   setLocaleMessage(locale: VueI18n.Locale, message: VueI18n.LocaleMessageObject): void;
   mergeLocaleMessage(locale: VueI18n.Locale, message: VueI18n.LocaleMessageObject): void;
@@ -225,8 +227,10 @@ declare class VueI18n {
   te(key: VueI18n.Path, locale?: VueI18n.Locale): boolean;
   d(value: number | Date, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.DateTimeFormatResult;
   d(value: number | Date, args?: { [key: string]: string }): VueI18n.DateTimeFormatResult;
+  d(value: number, options?: VueI18n.DateTimeFormatOptions): VueI18n.DateTimeFormatResult;  
   n(value: number, key?: VueI18n.Path, locale?: VueI18n.Locale): VueI18n.NumberFormatResult;
   n(value: number, args?: { [key: string]: string }): VueI18n.NumberFormatResult;
+  n(value: number, options?: VueI18n.NumberFormatOptions): VueI18n.NumberFormatResult;
 
   getLocaleMessage(locale: VueI18n.Locale): VueI18n.LocaleMessageObject;
   setLocaleMessage(locale: VueI18n.Locale, message: VueI18n.LocaleMessageObject): void;


### PR DESCRIPTION
The `Intl.NumberFormatOptions` and `Intl.DateTimeFormatOptions` values aren't just strings, therefore the current type `args?: { [key: string]: string }` is too narrow. 

Added a new overload to reflect this. I kept the old declaration for backward compatibility.

Should also fix #749