### PR TITLE
Expose BaseFormatter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const defaultModifiers = {
 
 const defaultFormatter = new BaseFormatter()
 
+export { BaseFormatter };
 export default class VueI18n {
   static install: () => void
   static version: string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -230,3 +230,4 @@ declare module 'vue/types/options' {
 }
 
 export default VueI18n;
+export { BaseFormatter };


### PR DESCRIPTION
As mentioned in #923 I've exposed the BaseFormatter class. This will allow you to slightly change the default behaviour.

```js

// Custom Formatter implementation
class CustomFormatter extends BaseFormatter {
     
     interpolate (message, values) {

       // Do anything you like to do
       message = message.replace('needle', 'replacement');

       return super.interpolate (message, values);
     }
}

// register with `formatter` option
const i18n = new VueI18n({
  locale: 'en-US',
  formatter: new CustomFormatter(),
  messages: {
    'en-US': {
      // ...
    }
  }
})
```
