### PR TITLE
Fix wrong type for LocaleMatcher ('best-fit' to 'best fit').

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,8 +17,8 @@ declare namespace VueI18n {
   interface LocaleMessages { [key: string]: LocaleMessageObject; }
   type TranslateResult = string | LocaleMessages;
 
-  type LocaleMatcher = 'lookup' | 'best-fit';
-  type FormatMatcher = 'basic' | 'best-fit';
+  type LocaleMatcher = 'lookup' | 'best fit';
+  type FormatMatcher = 'basic' | 'best fit';
 
   type DateTimeHumanReadable = 'long' | 'short' | 'narrow';
   type DateTimeDigital = 'numeric' | '2-digit';


### PR DESCRIPTION
Hi everyone!
I was testing if my project compiles with TS 4.2 RC. and it didn't because of wrong typing of vue-i18n :(
This fixes it.
Hope this is a good PR.

from commit message:

In Typescript 4.2 type definitions for Intl API was updated (https://github.com/microsoft/TypeScript/pull/41880).
Because of that we now have compile error when we try to compile vue-i18n in TS 4.2 RC.
The reason is our wrong type definition for "localeMatcher" and "formatMatcher" properties.
We had "best-fit" but it should be "best fit".

This was the error when we compile vue-i18n with Typescript 4.2 RC. Now it's fixed.:

    > npx typescript@4.2.1-rc -p types
    npx: installed 1 in 3.512s
    types/index.d.ts:26:13 - error TS2430: Interface 'SpecificDateTimeFormatOptions' incorrectly extends interface 'DateTimeFormatOptions'.
    Types of property 'localeMatcher' are incompatible.
        Type 'LocaleMatcher | undefined' is not assignable to type '"best fit" | "lookup" | undefined'.
        Type '"best-fit"' is not assignable to type '"best fit" | "lookup" | undefined'.

    26   interface SpecificDateTimeFormatOptions extends Intl.DateTimeFormatOptions {
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    Found 1 error.

