### PR TITLE
Add documentation for directive `choice` argument

### DIFF
--- a/gitbook/en/api.md
+++ b/gitbook/en/api.md
@@ -536,6 +536,7 @@ You can specify the below some options of `I18nOptions` constructor options of [
   - path: required, key of locale messages
   - locale: optional, locale
   - args: optional, for list or named formatting
+  - choice: optional, for pluralization
 
 - **Examples:**
 


### PR DESCRIPTION
The directive also accepts a `choice` argument for pluralization that works just like the second argument of `$tc` (but was missing in the documentation)