### PR TITLE
Allowing paths to be null for lookups.

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -289,7 +289,7 @@ export default class I18nPath {
       let i: number = 0
       while (i < length) {
         const value: any = last[paths[i]]
-        if (value === undefined) {
+        if (value === undefined || value === null) {
           return null
         }
         last = value

--- a/test/unit/path.test.js
+++ b/test/unit/path.test.js
@@ -89,4 +89,10 @@ describe('path', () => {
       assert.strictEqual(path.getPathValue({}, 'a.b.c[]d'), null)
     })
   })
+  
+  describe('obj: null child', () => {
+    it('should return null if parent is null', () => {
+      assert.strictEqual(path.getPathValue({ a: null }, 'a.b'), null)
+    })
+  })
 })


### PR DESCRIPTION
When working on my applications, occasionally locales or fallback locales would contain a null object (not undefined). This would result in a hard-to-understand and breaking null pointer error:

`TypeError: Cannot read property 'public_food' of null`.

With this PR, vuei18n returns the null gracefully instead of throwing an error.