### PR TITLE
[perf] Use Set so lookup of _dataListeners can be O(1)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export default class VueI18n {
   _dateTimeFormatters: Object
   _numberFormatters: Object
   _path: I18nPath
-  _dataListeners: Array<any>
+  _dataListeners: Set<any>
   _componentInstanceCreatedListener: ?ComponentInstanceCreatedListener
   _preserveDirectiveContent: boolean
   _warnHtmlInMessage: WarnHtmlInMessageLevel
@@ -105,7 +105,7 @@ export default class VueI18n {
     this._dateTimeFormatters = {}
     this._numberFormatters = {}
     this._path = new I18nPath()
-    this._dataListeners = []
+    this._dataListeners = new Set()
     this._componentInstanceCreatedListener = options.componentInstanceCreatedListener || null
     this._preserveDirectiveContent = options.preserveDirectiveContent === undefined
       ? false
@@ -240,7 +240,7 @@ export default class VueI18n {
   }
 
   subscribeDataChanging (vm: any): void {
-    this._dataListeners.push(vm)
+    this._dataListeners.add(vm)
   }
 
   unsubscribeDataChanging (vm: any): void {
@@ -250,12 +250,11 @@ export default class VueI18n {
   watchI18nData (): Function {
     const self = this
     return this._vm.$watch('$data', () => {
-      let i = self._dataListeners.length
-      while (i--) {
+      self._dataListeners.forEach(e => {
         Vue.nextTick(() => {
-          self._dataListeners[i] && self._dataListeners[i].$forceUpdate()
+          e && e.$forceUpdate()
         })
-      }
+      })
     }, { deep: true })
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -102,12 +102,9 @@ export function looseClone (obj: Object): Object {
   return JSON.parse(JSON.stringify(obj))
 }
 
-export function remove (arr: Array<any>, item: any): Array<any> | void {
-  if (arr.length) {
-    const index = arr.indexOf(item)
-    if (index > -1) {
-      return arr.splice(index, 1)
-    }
+export function remove (arr: Set<any>, item: any): Set<any> | void {
+  if (arr.delete(item)) {
+    return arr
   }
 }
 


### PR DESCRIPTION
Partially adresses #926 

This PR changes the internal `_dataListeners` from `Array` to `Set`, so lookup can be O(1) instead of O(n)
Original idea is proposed by  @emarbo in https://github.com/kazupon/vue-i18n/issues/926#issuecomment-816580379

Theoretically `Set` requires more memory than simple `Array`, but I think it can be negligible: the number of elements may be from dozens to hundreds for most cases.
Sacrificing some memory is rational improving time of destroying.

IIUC, `Set` is in all browsers supported by Vue 2.x: https://caniuse.com/?search=javascript%20set