### PR TITLE
Revert "fix: i18n reference to root causes memory leak (#1044)"

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -42,16 +42,6 @@ export default {
           options.i18n.silentFallbackWarn = rootI18n.silentFallbackWarn
           options.i18n.pluralizationRules = rootI18n.pluralizationRules
           options.i18n.preserveDirectiveContent = rootI18n.preserveDirectiveContent
-          this.$root.$once('hook:beforeDestroy', () => {
-            options.i18n.root = null;
-            options.i18n.formatter = null;
-            options.i18n.fallbackLocale = null;
-            options.i18n.formatFallbackMessages = null;
-            options.i18n.silentTranslationWarn = null;
-            options.i18n.silentFallbackWarn = null;
-            options.i18n.pluralizationRules = null;
-            options.i18n.preserveDirectiveContent = null;
-          });
         }
 
         // init locale messages via custom blocks

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -1,7 +1,6 @@
 import messages from './fixture/index'
 import { parse } from '../../src/format'
 import VueI18n from '../../src'
-import { Vue } from '../../src/install'
 const compiler = require('vue-template-compiler')
 
 const delay = time => new Promise(resolve => setTimeout(resolve, time))
@@ -498,42 +497,6 @@ describe('issues', () => {
         assert.strictEqual(vm.$refs.text4.textContent, 'Hello Module 2 shared key 2')
       }).then(done)
     })
-  })
-  // 1044
-  describe('#1044', () => {
-    it('should be free memory', done => {
-      const i18n = {
-        messages: {
-          hello: 'hello world!'
-        }
-      }
-      const Test = {
-        i18n,
-      }
-      const vm = new Vue({
-        components: {
-          Test
-        },
-        i18n: {
-          locale: 'en',
-        },
-        render (h) {
-          return h('Test')
-        }
-      }).$mount()
-      vm.$destroy();
-
-      assert.strictEqual(i18n.root, null)
-      assert.strictEqual(i18n.formatter, null)
-      assert.strictEqual(i18n.fallbackLocale, null)
-      assert.strictEqual(i18n.formatFallbackMessages, null)
-      assert.strictEqual(i18n.silentTranslationWarn, null)
-      assert.strictEqual(i18n.silentFallbackWarn, null)
-      assert.strictEqual(i18n.pluralizationRules, null)
-      assert.strictEqual(i18n.preserveDirectiveContent, null)
-
-      done();
-    });
   })
 
   describe('#78, #464', () => {


### PR DESCRIPTION
Reverts kazupon/vue-i18n#1151
due to be avoiding the current memory leaks issues.
#1190 #1191
