### PR TITLE
fix broken mergeLocaleMessage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -770,7 +770,7 @@ export default class VueI18n {
     }
     this._vm.$set(this._vm.messages, locale, merge(
       typeof this._vm.messages[locale] !== 'undefined' && Object.keys(this._vm.messages[locale]).length
-        ? this._vm.messages[locale]
+        ? Object.assign({}, this._vm.messages[locale])
         : {},
       message
     ))


### PR DESCRIPTION
This is a fix to #1108 

Changes in #1098 break mergeLocaleMessage because `_vm` will not be notified that `messages` has been updated, resulting in the behavior described in #1108.

I present this PR as a compromise.

Instead of doing a deep copy with an empty object, we do a shallow copy so that change events will be invoked correctly while improving the performance somewhat.

I don't think there is another workaround without doing substantial changes to core structure.