### PR TITLE
fix: fix e2e test failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-istanbul": "^6.0.0",
     "babel-preset-power-assert": "^3.0.0",
     "buble": "^0.19.3",
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^97.0.0",
     "core-js": "^3.6.5",
     "cross-env": "^7.0.2",
     "cross-spawn": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,10 +3136,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^95.0.0:
-  version "95.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-95.0.0.tgz#ecf854cac6df5137a651dcc132edf55612d3db7f"
-  integrity sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==
+chromedriver@^97.0.0:
+  version "97.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-97.0.0.tgz#7005b1a15a6456558d0fc4d5b72c98c12d1b033d"
+  integrity sha512-SZ9MW+/6/Ypz20CNdRKocsmRM2AJ/YwHaWpA1Np2QVPFUbhjhus6vBtqFD+l8M5qrktLWPQSjTwIsDckNfXIRg==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.2"


### PR DESCRIPTION
The `e2e test` is failing cause the `chrome` is updated to version 97.x, but the `chromedriver` is still using version `95.x`.

This is a fix.