### PR TITLE
Restrict version to 8 for installing npm package

### DIFF
--- a/vuepress/installation.md
+++ b/vuepress/installation.md
@@ -21,13 +21,13 @@ Include vue-i18n after Vue and it will install itself automatically:
 ## NPM
 
 ```sh
-npm install vue-i18n
+npm install vue-i18n@8
 ```
 
 ## Yarn
 
 ```sh
-yarn add vue-i18n
+yarn add vue-i18n@8
 ```
 
 When using with a module system, you must explicitly install the `vue-i18n`


### PR DESCRIPTION
The docs for version 8 suggest that the latest version of `vue-i18n` should be installed. However that currently installs version 9 which is incompatible with Vue 2.

I'm not sure what other parts of the installation guide should be updated (e.g. Vue CLI) to have the correct version installed 