### PR TITLE
Allow colon in locale message keys used in linked locale messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import I18nPath from './path'
 import type { PathValue } from './path'
 
 const htmlTagMatcher = /<\/?[\w\s="/.':;#-\/]+>/
-const linkKeyMatcher = /(?:@(?:\.[a-z]+)?:(?:[\w\-_|./]+|\([\w\-_|./]+\)))/g
+const linkKeyMatcher = /(?:@(?:\.[a-z]+)?:(?:[\w\-_|./]+|\([\w\-_:|./]+\)))/g
 const linkKeyPrefixMatcher = /^@(?:\.([a-z]+))?:/
 const bracketsMatcher = /[()]/g
 const defaultModifiers = {

--- a/test/unit/basic.test.js
+++ b/test/unit/basic.test.js
@@ -68,6 +68,13 @@ describe('basic', () => {
       it('should render link with custom formatting.', () => {
         assert.strictEqual(i18n.t('message.linkCaseCustom'), 'hxmx Addrxss')
       })
+
+      it('should translate link when keys have special characters', () => {
+        assert.strictEqual(i18n.t('message.linkHyphen'), messages.en['hyphen-hello'])
+        assert.strictEqual(i18n.t('message.linkUnderscore'), messages.en.underscore_hello)
+        assert.strictEqual(i18n.t('message.linkColon'), messages.en['colon:hello'])
+        assert.strictEqual(i18n.t('message.linkPipe'), messages.en['pipe|hello'])
+      })
     })
 
     describe('ja locale', () => {

--- a/test/unit/fixture/index.js
+++ b/test/unit/fixture/index.js
@@ -19,6 +19,8 @@ export default {
       linkBrackets: 'Hello @:(message.hoge). Isn\'t @:(message.hello) great?',
       linkHyphen: '@:hyphen-hello',
       linkUnderscore: '@:underscore_hello',
+      linkPipe: '@:pipe|hello',
+      linkColon: '@:(colon:hello)',
       linkList: '@:message.hello: {0} {1}',
       linkCaseLower: 'Please provide @.lower:message.homeAddress',
       linkCaseUpper: '@.upper:message.homeAddress',
@@ -45,6 +47,8 @@ export default {
     'hyphen-hello': 'hyphen the wolrd',
     /* eslint-disable */
     underscore_hello: 'underscore the wolrd',
+    'colon:hello': 'hello colon',
+    'pipe|hello': 'hello pipe',
     /* eslint-enable */
     underscore: '{helloMsg} world',
     plurals: {

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -813,4 +813,11 @@ describe('issues', () => {
       }).then(done)
     })
   })
+
+  describe('#1488', () => {
+    it('should be translated', () => {
+      assert.strictEqual(vm.$i18n.t('message.linkColon'), messages.en['colon:hello'])
+      assert.strictEqual(vm.$i18n.t('message.linkPipe'), messages.en['pipe|hello'])
+    })
+  })
 })


### PR DESCRIPTION
[Linked Locale Messages](https://kazupon.github.io/vue-i18n/guide/messages.html#formatting-linked-locale-messages) break when the linked locale message key contains a `:` character.  This updates a regex to allow for keys containing `:`, as long as the linked locale message uses the brackets syntax.

example:

```
{
  "homeAddress:phrase": "Home Address",
  "missingHomeAddress:validation": 'Please provide @.lower:(homeAddress:phrase)'
}
```