### PR TITLE
Allow modifiers names in pascalCase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,8 @@ import I18nPath from './path'
 import type { PathValue } from './path'
 
 const htmlTagMatcher = /<\/?[\w\s="/.':;#-\/]+>/
-const linkKeyMatcher = /(?:@(?:\.[a-z]+)?:(?:[\w\-_|./]+|\([\w\-_:|./]+\)))/g
-const linkKeyPrefixMatcher = /^@(?:\.([a-z]+))?:/
+const linkKeyMatcher = /(?:@(?:\.[a-zA-Z]+)?:(?:[\w\-_|./]+|\([\w\-_:|./]+\)))/g
+const linkKeyPrefixMatcher = /^@(?:\.([a-zA-Z]+))?:/
 const bracketsMatcher = /[()]/g
 const defaultModifiers = {
   'upper': str => str.toLocaleUpperCase(),

--- a/test/unit/issues.test.js
+++ b/test/unit/issues.test.js
@@ -820,4 +820,24 @@ describe('issues', () => {
       assert.strictEqual(vm.$i18n.t('message.linkPipe'), messages.en['pipe|hello'])
     })
   })
+
+  describe('#1308', () => {
+    it('should be translated', () => {
+      const i18n = new VueI18n({
+          locale: 'en',
+          messages: {
+            en: {
+              'address': 'home Address',
+              'snakeAddress': '@.snakeCase:(address)'
+            }
+          },
+          name: 'test',
+          modifiers: {
+            snakeCase: str => str.split(' ').join('-')
+          },
+      })
+
+      assert.strictEqual(i18n.t('snakeAddress'), 'home-Address')
+    })
+  })
 })


### PR DESCRIPTION
PR to support different name formats for modifiers. Related to #1308 
The official documentation doesn't state that modifier names should be written in lowercase, so i suggest that it wouldn't be wrong to allow naming them any case you want.