### PR TITLE
Add availableLocales to I18nOptions interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -139,6 +139,7 @@ declare namespace VueI18n {
     locale?: Locale;
     fallbackLocale?: FallbackLocale;
     messages?: LocaleMessages;
+    availableLocales?: Locale[];
     dateTimeFormats?: DateTimeFormats;
     numberFormats?: NumberFormats;
     formatter?: Formatter;


### PR DESCRIPTION
Add `availableLocales` to the `I18nOptions` interface, so it can be defined in the `VueI18n` instance.

```
import Vue from 'vue';
import VueI18n from 'vue-i18n';

const i18n = new VueI18n({
    locale,
    availableLocales,
    fallbackLocale,
    messages,
    silentTranslationWarn: true
});
```