### PR TITLE
fix(datetime): $d supports key format object (#1502)

### DIFF
--- a/examples/datetime/index.html
+++ b/examples/datetime/index.html
@@ -10,25 +10,32 @@
   <body>
     <div id="app">
       <select v-model="locale">
-        <option>en-US</option>
-        <option>ja-JP</option>
+        <option value="en-US">en-US</option>
+        <option value="ja-JP">ja-JP</option>
       </select>
       <p>{{ $t('current_datetime')}}: {{ $d(now, 'long') }}</p>
+      <p data-testid="pastDatetime">{{ $t('past_datetime')}}: {{ $d(pastDatetime, 'long') }}</p>
+      <p data-testid="pastYear">{{ $t('past_year')}}: {{ $d(pastDatetime, {year: '2-digit'}) }}</p>
     </div>
     <script>
       var messages = {
         'en-US': {
-          current_datetime: 'current datetime'
+          current_datetime: 'current datetime',
+          past_datetime: 'past datetime',
+          past_year: 'past year'
         },
         'ja-JP': {
-          current_datetime: '現在の日時'
+          current_datetime: '現在の日時',
+          past_datetime: '過去の日時',
+          past_year: '過去の年'
         }
       }
       var dateTimeFormats = {
         'en-US': {
           long: {
             year: 'numeric', month: '2-digit', day: '2-digit',
-            hour: '2-digit', minute: '2-digit', second: '2-digit'
+            hour: '2-digit', minute: '2-digit', second: '2-digit',
+            timeZone: 'America/Los_Angeles'
           }
         },
         'ja-JP': {
@@ -36,6 +43,7 @@
             year: 'numeric', month: '2-digit', day: '2-digit',
             hour: '2-digit', minute: '2-digit', second: '2-digit',
             hour12: true,
+            timeZone: 'Asia/Tokyo'
           }
         }
       }
@@ -53,7 +61,8 @@
         i18n: i18n,
         data: {
           locale: initial,
-          now: new Date()
+          now: new Date(),
+          pastDatetime: new Date(Date.UTC(2012, 11, 20, 3, 0, 0))
         },
         watch: {
           locale: function (val) {

--- a/src/util.js
+++ b/src/util.js
@@ -24,6 +24,18 @@ export const numberFormatKeys = [
   'maximumSignificantDigits'
 ]
 
+export const dateTimeFormatKeys = [
+  'weekday',
+  'era',
+  'year',
+  'month',
+  'day',
+  'hour',
+  'minute',
+  'second',
+  'timeZoneName'
+]
+
 /**
  * utilities
  */

--- a/test/e2e/test/datetime.js
+++ b/test/e2e/test/datetime.js
@@ -1,0 +1,13 @@
+module.exports = {
+  number: function (browser) {
+    browser
+      .url('http://localhost:8080/examples/datetime/')
+      .waitForElementVisible('#app', 1000)
+      .assert.containsText('p[data-testid="pastDatetime"]', '過去の日時: 2012/12/20 午後00:00:00')
+      .assert.containsText('p[data-testid="pastYear"]', '過去の年: 12年')
+      .click('select option[value=en-US]')
+      .assert.containsText('p[data-testid="pastDatetime"]', 'past datetime: 12/19/2012, 07:00:00 PM')
+      .assert.containsText('p[data-testid="pastYear"]', 'past year: 12')
+      .end()
+  }
+}


### PR DESCRIPTION
This PR is a fix for the issue #1502.

### What was fixed
- $d supports key format object like $n

### How it was fixed
- Add a new logic to parse the $d parameter and handled it as options for Intl.DateTimeFormat. The logic is the same as $n.
- Add a new test case for key format object.

### Result
`$d(datetime, {year: '2-digit'})` returns correct value.

<img width="500" alt="スクリーンショット 2022-10-29 22 37 01" src="https://user-images.githubusercontent.com/20832866/198835147-1d3d7336-dcc7-4c4d-b4f0-f0d86d240627.png">

<img width="524" alt="スクリーンショット 2022-10-29 22 37 14" src="https://user-images.githubusercontent.com/20832866/198835154-00b59b5d-deba-475b-9967-364f02e81469.png">
