### PR TITLE
fix(docs): fix wrong document (availableLocales)

### DIFF
--- a/vuepress/api/README.md
+++ b/vuepress/api/README.md
@@ -222,18 +222,6 @@ The number formats of localization.
 
   * **See also:** `NumberFormats` type of [flowtype definitions](https://github.com/kazupon/vue-i18n/blob/dev/decls/i18n.js)
 
-#### availableLocales
-
-> :new: 8.9.0+
-
-  * **Type:** `Locale[]`
-
-  * **Default:** `[]`
-
-  * **Examples:** `["en", "ja"]`
-
-The list of available locales in `messages` in lexical order.
-
 #### formatter
 
   * **Type:** `Formatter`
@@ -461,6 +449,16 @@ The datetime formats of localization.
   * **Read only**
 
 The number formats of localization.
+
+#### availableLocales
+
+> :new: 8.9.0+
+
+  * **Type:** `Locale[]`
+
+  * **Read only**
+
+The list of available locales in `messages` in lexical order.
 
 #### missing
 


### PR DESCRIPTION
This PR is a fix of issue #1528.

## Result
**Before:**
Docs say `availableLocales` can be passed to the constructor option. 
<img width="1440" alt="スクリーンショット 2022-11-02 8 24 35" src="https://user-images.githubusercontent.com/20832866/199361737-b09af511-7603-449f-bfcf-3d23bc7470c7.png">


**After:** 
Removed `availableLocales`  from  the constructor option. 
<img width="1436" alt="スクリーンショット 2022-11-02 8 28 39" src="https://user-images.githubusercontent.com/20832866/199361984-9c336a58-0f5c-439e-966c-dc6c84598b2c.png">

And `availableLocales` is moved to the Properties section.
<img width="1436" alt="スクリーンショット 2022-11-02 8 29 42" src="https://user-images.githubusercontent.com/20832866/199362023-b2097e20-dde7-446c-93c3-9844bf68f780.png">

